### PR TITLE
MRG: hrf refactor

### DIFF
--- a/examples/plot_design_matrix.py
+++ b/examples/plot_design_matrix.py
@@ -31,8 +31,8 @@ frame_times = np.arange(n_scans) * tr
 # experimental paradigm
 conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c1', 'c3', 'c3', 'c3']
 onsets = [30., 70., 100., 10., 30., 90., 30., 40., 60.]
-hrf_model = 'canonical'
 motion = np.cumsum(np.random.randn(n_scans, 6), 0)  # simulate motion
+hrf_model = 'glover'
 add_reg_names = ['tx', 'ty', 'tz', 'rx', 'ry', 'rz']
 
 # event-related design matrix

--- a/examples/plot_hrf.py
+++ b/examples/plot_hrf.py
@@ -18,7 +18,7 @@ onset, amplitude, duration = 0., 1., 1.
 stim = np.zeros_like(frame_times)
 stim[(frame_times > onset) * (frame_times <= onset + duration)] = amplitude
 exp_condition = np.array((onset, duration, amplitude)).reshape(3, 1)
-hrf_models = ['canonical with derivative', 'spm_time_dispersion']
+hrf_models = ['glover + derivative', 'spm + derivative + dispersion']
 
 
 fig = plt.figure(figsize=(9, 4))

--- a/examples/plot_hrf.py
+++ b/examples/plot_hrf.py
@@ -1,0 +1,20 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from nistats import hemodynamic_models
+
+
+
+frame_times = np.linspace(0, 30, 61)
+
+onset, amplitude, duration = 0., 1., 1. 
+exp_condition = np.array((onset, amplitude, duration)).reshape(3, 1)
+hrf_model = 'canonical with derivative'
+
+signal, name = hemodynamic_models.compute_regressor(
+    exp_condition, hrf_model, frame_times, con_id='cond',
+    oversampling=2, fir_delays=None, min_onset=-24)
+
+plt.plot(frame_times, signal)
+plt.xlabel('time (s)')
+plt.title(name)
+plt.show()

--- a/examples/plot_hrf.py
+++ b/examples/plot_hrf.py
@@ -1,20 +1,40 @@
+""" 
+Example of hemodynamic reponse functions.
+We consider the hrf model in SPM together with the hrf shape proposed
+by G.Glover, as well as their time and dispersion derivatives.
+
+Author: Bertrand Thirion, 2015.
+"""
+print __doc__
+
 import numpy as np
 import matplotlib.pyplot as plt
 from nistats import hemodynamic_models
 
 
-
+# parameters
 frame_times = np.linspace(0, 30, 61)
-
-onset, amplitude, duration = 0., 1., 1. 
+onset, amplitude, duration = 0., 1., 1.
+stim = np.zeros_like(frame_times)
+stim[(frame_times > onset) * (frame_times <= onset + duration)] = amplitude
 exp_condition = np.array((onset, amplitude, duration)).reshape(3, 1)
-hrf_model = 'canonical with derivative'
+hrf_models = ['canonical with derivative', 'spm_time_dispersion']
 
-signal, name = hemodynamic_models.compute_regressor(
-    exp_condition, hrf_model, frame_times, con_id='cond',
-    oversampling=2, fir_delays=None, min_onset=-24)
 
-plt.plot(frame_times, signal)
-plt.xlabel('time (s)')
-plt.title(name)
-plt.show()
+fig = plt.figure(figsize=(9, 4))
+# sample the hrf
+for i, hrf_model in enumerate(hrf_models):
+    signal, name = hemodynamic_models.compute_regressor(
+        exp_condition, hrf_model, frame_times, con_id='main',
+        oversampling=2)
+
+    plt.subplot(1, 2, i)
+    plt.fill(frame_times, stim, 'k', alpha=.5, label='stimulus')
+    for j in range(signal.shape[1]):
+        plt.plot(frame_times, signal.T[j], label=name[j])
+    plt.xlabel('time (s)')
+    plt.legend(loc=1)
+    plt.title(hrf_model)
+
+plt.subplots_adjust(bottom=.12)
+fig.show()

--- a/examples/plot_hrf.py
+++ b/examples/plot_hrf.py
@@ -17,7 +17,7 @@ frame_times = np.linspace(0, 30, 61)
 onset, amplitude, duration = 0., 1., 1.
 stim = np.zeros_like(frame_times)
 stim[(frame_times > onset) * (frame_times <= onset + duration)] = amplitude
-exp_condition = np.array((onset, amplitude, duration)).reshape(3, 1)
+exp_condition = np.array((onset, duration, amplitude)).reshape(3, 1)
 hrf_models = ['canonical with derivative', 'spm_time_dispersion']
 
 
@@ -26,7 +26,7 @@ fig = plt.figure(figsize=(9, 4))
 for i, hrf_model in enumerate(hrf_models):
     signal, name = hemodynamic_models.compute_regressor(
         exp_condition, hrf_model, frame_times, con_id='main',
-        oversampling=2)
+        oversampling=16)
 
     plt.subplot(1, 2, i)
     plt.fill(frame_times, stim, 'k', alpha=.5, label='stimulus')

--- a/examples/plot_hrf.py
+++ b/examples/plot_hrf.py
@@ -18,7 +18,7 @@ onset, amplitude, duration = 0., 1., 1.
 stim = np.zeros_like(frame_times)
 stim[(frame_times > onset) * (frame_times <= onset + duration)] = amplitude
 exp_condition = np.array((onset, duration, amplitude)).reshape(3, 1)
-hrf_models = ['glover + derivative', 'spm + derivative + dispersion']
+hrf_models = ['glover + derivative', 'glover + derivative + dispersion']
 
 
 fig = plt.figure(figsize=(9, 4))
@@ -28,7 +28,7 @@ for i, hrf_model in enumerate(hrf_models):
         exp_condition, hrf_model, frame_times, con_id='main',
         oversampling=16)
 
-    plt.subplot(1, 2, i)
+    plt.subplot(1, 2, i + 1)
     plt.fill(frame_times, stim, 'k', alpha=.5, label='stimulus')
     for j in range(signal.shape[1]):
         plt.plot(frame_times, signal.T[j], label=name[j])

--- a/examples/plot_localizer_analysis.py
+++ b/examples/plot_localizer_analysis.py
@@ -44,9 +44,10 @@ fmri_img = data.epi_img
 
 paradigm = pd.read_csv(paradigm_file, sep=' ', header=None, index_col=None)
 paradigm.columns = ['session', 'name', 'onset']
+n_conditions = len(paradigm.name.unique())
 design_matrix = make_design_matrix(
-    frame_times, paradigm, hrf_model='canonical with derivative',
-    drift_model="cosine", period_cut=128)
+    frame_times, paradigm, hrf_model='glover + derivative',
+    drift_model='cosine', period_cut=128)
 
 ### Perform a GLM analysis ########################################
 

--- a/examples/plot_spm_auditory.py
+++ b/examples/plot_spm_auditory.py
@@ -37,8 +37,8 @@ paradigm = pd.DataFrame(
 # construct design matrix
 frame_times = np.linspace(0, (n_scans - 1) * tr, n_scans)
 drift_model = 'Cosine'
-hrf_model = 'Canonical With Derivative'
 period_cut = 4. * epoch_duration
+hrf_model = 'glover + derivative'
 design_matrix = make_design_matrix(
     frame_times, paradigm, hrf_model=hrf_model, drift_model=drift_model,
     period_cut=period_cut)

--- a/examples/plot_spm_multimodal_faces.py
+++ b/examples/plot_spm_multimodal_faces.py
@@ -32,7 +32,7 @@ subject_data = fetch_spm_multimodal_fmri()
 # experimental paradigm meta-params
 tr = 2.
 drift_model = 'Cosine'
-hrf_model = 'Canonical With Derivative'
+hrf_model = 'spm + derivative'
 period_cut = 128.
 
 # resample the images

--- a/nistats/design_matrix.py
+++ b/nistats/design_matrix.py
@@ -16,6 +16,11 @@ Design matrices contain three different types of regressors:
    A hemodynamic model is one of:
    'spm' : linear filter used in the SPM software
    'glover' : linear filter estimated by G.Glover
+   'spm + derivative', 'glover + derivative': the same linear models,
+       plus their time derivative (2 regressors per condition)
+   'spm + derivative + dispersion', 'glover + derivative + dispersion':
+       idem plus the derivative wrt the dispersion parameter of the hrf
+       (3 regressors per condition)
    'fir' : finite impulse response model, generic linear filter
 
 2. User-specified regressors, that represent information available on
@@ -168,7 +173,8 @@ def _convolve_regressors(paradigm, hrf_model, frame_times, fir_delays=[0],
         for these to be valid paradigm descriptors
 
     hrf_model : {'spm', 'spm + derivative', 'spm + derivative + dispersion',
-        'glover', 'glover + derivative', 'fir'}
+        'glover', 'glover + derivative', 'glover + derivative + dispersion',
+        'fir'}
         String that specifies the hemodynamic response function
 
     frame_times : array of shape (n_scans,)
@@ -193,9 +199,10 @@ def _convolve_regressors(paradigm, hrf_model, frame_times, fir_delays=[0],
         if 'glover' or 'spm' then this is identical to the input names
         if 'glover + derivative' or 'spm + derivative', a second name is output
             i.e. '#name_derivative'
-        if 'spm + derivative + dispersion', a third name is used,
-            i.e. '#name_dispersion'
-        if 'fir', a the strings
+        if 'spm + derivative + dispersion' or
+            'glover + derivative + dispersion',
+            a third name is used, i.e. '#name_dispersion'
+        if 'fir', the regressos are numbered accoding to '#name_#delay'
     """
     regressor_names = []
     regressor_matrix = None
@@ -277,7 +284,8 @@ def make_design_matrix(
         Description of the experimental paradigm.
 
     hrf_model : {'spm', 'spm + derivative', 'spm + derivative + dispersion',
-        'glover', 'glover + derivative', 'fir'}, optional,
+        'glover', 'glover + derivative', 'glover + derivative + dispersion',
+        'fir'}, optional,
         Specifies the hemodynamic response function
 
     drift_model : string, optional

--- a/nistats/design_matrix.py
+++ b/nistats/design_matrix.py
@@ -210,6 +210,7 @@ def _convolve_regressors(paradigm, hrf_model, frame_times, fir_delays=[0],
             exp_condition, hrf_model, frame_times, con_id=condition,
             fir_delays=fir_delays, oversampling=oversampling,
             min_onset=min_onset)
+
         regressor_names += names
         if regressor_matrix is None:
             regressor_matrix = reg

--- a/nistats/design_matrix.py
+++ b/nistats/design_matrix.py
@@ -167,8 +167,9 @@ def _convolve_regressors(paradigm, hrf_model, frame_times, fir_delays=[0],
         see nistats.experimental_paradigm to check the specification
         for these to be valid paradigm descriptors
 
-    hrf_model : {'canonical', 'canonical with derivative', 'fir'}
-        String that specifies the hemodynamic response function.
+    hrf_model : {'spm', 'spm + derivative', 'spm + derivative + dispersion',
+        'glover', 'glover + derivative', 'fir'}
+        String that specifies the hemodynamic response function
 
     frame_times : array of shape (n_scans,)
         The targeted timing for the design matrix.
@@ -189,9 +190,12 @@ def _convolve_regressors(paradigm, hrf_model, frame_times, fir_delays=[0],
 
     regressor_names : list of strings,
         The regressor names, that depend on the hrf model used
-        if 'canonical' then this is identical to the input names
-        if 'canonical with derivative', then two names are produced for
-        input name 'name': 'name' and 'name_derivative'
+        if 'glover' or 'spm' then this is identical to the input names
+        if 'glover + derivative' or 'spm + derivative', a second name is output
+            i.e. '#name_derivative'
+        if 'spm + derivative + dispersion', a third name is used,
+            i.e. '#name_dispersion'
+        if 'fir', a the strings
     """
     regressor_names = []
     regressor_matrix = None
@@ -259,7 +263,7 @@ def _full_rank(X, cmax=1e15):
 
 
 def make_design_matrix(
-    frame_times, paradigm=None, hrf_model='canonical',
+    frame_times, paradigm=None, hrf_model='glover',
     drift_model='cosine', period_cut=128, drift_order=1, fir_delays=[0],
     add_regs=None, add_reg_names=None, min_onset=-24):
     """Generate a design matrix from the input parameters
@@ -272,9 +276,9 @@ def make_design_matrix(
     paradigm : DataFrame instance, optional
         Description of the experimental paradigm.
 
-    hrf_model : string, optional,
-        Specifies the hemodynamic response function (HRF).
-        It can be 'canonical', 'canonical with derivative' or 'fir'
+    hrf_model : {'spm', 'spm + derivative', 'spm + derivative + dispersion',
+        'glover', 'glover + derivative', 'fir'}, optional,
+        Specifies the hemodynamic response function
 
     drift_model : string, optional
         Specifies the desired drift model,

--- a/nistats/hemodynamic_models.py
+++ b/nistats/hemodynamic_models.py
@@ -193,7 +193,6 @@ def spm_dispersion_derivative(tr, oversampling=16, time_length=32., onset=0.):
         - _gamma_difference_hrf(tr, oversampling, time_length,
                                 onset, dispersion=1. + dd)
         + _gamma_difference_hrf(tr, oversampling, time_length, onset))
-    dhrf *= 10
     return dhrf
 
 
@@ -307,7 +306,7 @@ def _orthogonalize(X):
     from scipy.linalg import pinv, norm
     for i in range(1, X.shape[1]):
         X[:, i] -= np.dot(np.dot(X[:, i], X[:, :i]), pinv(X[:, :i]))
-        X[:, i] /= norm(X[:, i])
+        # X[:, i] /= norm(X[:, i])
     return X
 
 

--- a/nistats/hemodynamic_models.py
+++ b/nistats/hemodynamic_models.py
@@ -367,6 +367,9 @@ def _hrf_kernel(hrf_model, tr, oversampling=16, fir_delays=None):
     hkernel : list of arrays
         samples of the hrf (the number depends on the hrf_model used)
     """
+    acceptable_hrfs = [
+        'spm', 'spm + derivative', 'spm + derivative + dispersion',
+        'glover', 'glover + derivative', 'fir']
     if hrf_model == 'spm':
         hkernel = [spm_hrf(tr, oversampling)]
     elif hrf_model == 'spm + derivative':
@@ -386,7 +389,8 @@ def _hrf_kernel(hrf_model, tr, oversampling=16, fir_delays=None):
                               np.ones(oversampling)))
                    for f in fir_delays]
     else:
-        raise ValueError('Unknown hrf model')
+        raise ValueError('"{0}" is not a known hrf model. Use one of {1}'.
+                         format(hrf_model, acceptable_hrfs))
     return hkernel
 
 

--- a/nistats/hemodynamic_models.py
+++ b/nistats/hemodynamic_models.py
@@ -54,7 +54,7 @@ def _gamma_difference_hrf(tr, oversampling=16, time_length=32., onset=0.,
     dt = tr / oversampling
     time_stamps = np.linspace(0, time_length, float(time_length) / dt)
     time_stamps -= onset
-    hrf = gamma.pdf(time_stamps, delay / dispersion, dt / dispersion) - \
+    hrf = gamma.pdf(time_stamps, delay / dispersion, dt / dispersion) -\
         ratio * gamma.pdf(
         time_stamps, undershoot / u_dispersion, dt / u_dispersion)
     hrf /= hrf.sum()
@@ -330,15 +330,15 @@ def _regressor_names(con_name, hrf_model, fir_delays=None):
     names: list of strings,
         regressor names
     """
-    if hrf_model == 'canonical':
+    if hrf_model == 'glover':
         return [con_name]
-    elif hrf_model == "canonical with derivative":
+    elif hrf_model == "glover + derivative":
         return [con_name, con_name + "_derivative"]
     elif hrf_model == 'spm':
         return [con_name]
-    elif hrf_model == 'spm_time':
+    elif hrf_model == 'spm + derivative':
         return [con_name, con_name + "_derivative"]
-    elif hrf_model == 'spm_time_dispersion':
+    elif hrf_model == 'spm + derivative + dispersion':
         return [con_name, con_name + "_derivative", con_name + "_dispersion"]
     elif hrf_model == 'fir':
         return [con_name + "_delay_%d" % i for i in fir_delays]
@@ -369,16 +369,16 @@ def _hrf_kernel(hrf_model, tr, oversampling=16, fir_delays=None):
     """
     if hrf_model == 'spm':
         hkernel = [spm_hrf(tr, oversampling)]
-    elif hrf_model == 'spm_time':
+    elif hrf_model == 'spm + derivative':
         hkernel = [spm_hrf(tr, oversampling),
                    spm_time_derivative(tr, oversampling)]
-    elif hrf_model == 'spm_time_dispersion':
+    elif hrf_model == 'spm + derivative + dispersion':
         hkernel = [spm_hrf(tr, oversampling),
                    spm_time_derivative(tr, oversampling),
                    spm_dispersion_derivative(tr, oversampling)]
-    elif hrf_model == 'canonical':
+    elif hrf_model == 'glover':
         hkernel = [glover_hrf(tr, oversampling)]
-    elif hrf_model == 'canonical with derivative':
+    elif hrf_model == 'glover + derivative':
         hkernel = [glover_hrf(tr, oversampling),
                    glover_time_derivative(tr, oversampling)]
     elif hrf_model == 'fir':
@@ -400,9 +400,9 @@ def compute_regressor(exp_condition, hrf_model, frame_times, con_id='cond',
         yields description of events for this condition as a
         (onsets, durations, amplitudes) triplet
 
-    hrf_model : {'spm', 'spm_time', 'spm_time_dispersion', 'canonical',
-        'canonical_derivative', 'fir'}
-        Name of the hrf model to be used.
+    hrf_model : {'spm', 'spm + derivative', 'spm + derivative + dispersion',
+        'glover', 'glover + derivative', 'fir'}
+        Name of the hrf model to be used
 
     frame_times : array of shape (n_scans)
         the desired sampling times
@@ -431,18 +431,18 @@ def compute_regressor(exp_condition, hrf_model, frame_times, con_id='cond',
     Notes
     -----
     The different hemodynamic models can be understood as follows:
-    'spm': this is the hrf model used in spm
-    'spm_time': this is the spm model plus its time derivative (2 regressors)
-    'spm_time_dispersion': idem, plus dispersion derivative (3 regressors)
-    'canonical': this one corresponds to the Glover hrf
-    'canonical_derivative': the Glover hrf + time derivative (2 regressors)
+    'spm': this is the hrf model used in SPM
+    'spm + derivative': SPM model plus its time derivative (2 regressors)
+    'spm + time + dispersion': idem, plus dispersion derivative (3 regressors)
+    'glover': this one corresponds to the Glover hrf
+    'glover + derivative': the Glover hrf + time derivative (2 regressors)
     'fir': finite impulse response basis, a set of delayed dirac models
            with arbitrary length. This one currently assumes regularly spaced
            frame times (i.e. fixed time of repetition).
     It is expected that spm standard and Glover model would not yield
     large differences in most cases.
 
-    In case of canonical and spm models, the derived regressors are
+    In case of glover and spm models, the derived regressors are
     orthogonalized wrt the main one.
     """
     # this is the average tr in this session, not necessarily the true tr

--- a/nistats/hemodynamic_models.py
+++ b/nistats/hemodynamic_models.py
@@ -136,8 +136,8 @@ def spm_time_derivative(tr, oversampling=16, time_length=32., onset=0.):
           dhrf sampling on the provided grid
     """
     do = .1
-    dhrf = 1. / do * (spm_hrf(tr, oversampling, time_length, onset + do) -
-                      spm_hrf(tr, oversampling, time_length, onset))
+    dhrf = 1. / do * (spm_hrf(tr, oversampling, time_length, onset) -
+                      spm_hrf(tr, oversampling, time_length, onset + do))
     return dhrf
 
 
@@ -161,8 +161,8 @@ def glover_time_derivative(tr, oversampling=16, time_length=32., onset=0.):
           dhrf sampling on the provided grid
     """
     do = .1
-    dhrf = 1. / do * (glover_hrf(tr, oversampling, time_length, onset + do) -
-                      glover_hrf(tr, oversampling, time_length, onset))
+    dhrf = 1. / do * (glover_hrf(tr, oversampling, time_length, onset) -
+                      glover_hrf(tr, oversampling, time_length, onset + do))
     return dhrf
 
 
@@ -189,9 +189,11 @@ def spm_dispersion_derivative(tr, oversampling=16, time_length=32., onset=0.):
           dhrf sampling on the oversampled time grid
     """
     dd = .01
-    dhrf = 1. / dd * (_gamma_difference_hrf(tr, oversampling, time_length,
-                                           onset, dispersion=1. + dd) -
-                      spm_hrf(tr, oversampling, time_length, onset))
+    dhrf = 1. / dd * (
+        - _gamma_difference_hrf(tr, oversampling, time_length,
+                                onset, dispersion=1. + dd)
+        + _gamma_difference_hrf(tr, oversampling, time_length, onset))
+    dhrf *= 10
     return dhrf
 
 

--- a/nistats/hemodynamic_models.py
+++ b/nistats/hemodynamic_models.py
@@ -53,7 +53,7 @@ def _gamma_difference_hrf(tr, oversampling=16, time_length=32., onset=0.,
     """
     dt = tr / oversampling
     time_stamps = np.linspace(0, time_length, float(time_length) / dt)
-    time_stamps -= onset / dt
+    time_stamps -= onset
     hrf = gamma.pdf(time_stamps, delay / dispersion, dt / dispersion) - \
         ratio * gamma.pdf(
         time_stamps, undershoot / u_dispersion, dt / u_dispersion)
@@ -304,9 +304,10 @@ def _orthogonalize(X):
     """
     if X.size == X.shape[0]:
         return X
-    from scipy.linalg import pinv
+    from scipy.linalg import pinv, norm
     for i in range(1, X.shape[1]):
-        X[:, i] -= np.dot(X[:, i], np.dot(X[:, :i], pinv(X[:, :i])))
+        X[:, i] -= np.dot(np.dot(X[:, i], X[:, :i]), pinv(X[:, :i]))
+        X[:, i] /= norm(X[:, i])
     return X
 
 

--- a/nistats/tests/test_dmtx.py
+++ b/nistats/tests/test_dmtx.py
@@ -187,7 +187,7 @@ def test_design_matrix1b():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Glover'
+    hrf_model = 'glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                         drift_model='polynomial', drift_order=3)
     assert_equal(X.shape, (128, 7))
@@ -198,7 +198,7 @@ def test_design_matrix1c():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Glover'
+    hrf_model = 'glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                         drift_model='polynomial', drift_order=3)
     assert_true((X[:, - 1] == 1).all())
@@ -209,7 +209,7 @@ def test_design_matrix1d():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Glover'
+    hrf_model = 'glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                         drift_model='polynomial', drift_order=3)
     assert_true((np.isnan(X) == 0).all())
@@ -220,7 +220,7 @@ def test_design_matrix2():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Glover'
+    hrf_model = 'glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                         drift_model='cosine', period_cut=63)
     assert_equal(len(names), 7)  # was 8 with old cosine
@@ -231,7 +231,7 @@ def test_design_matrix3():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Glover'
+    hrf_model = 'glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                         drift_model='blank')
     assert_equal(len(names), 4)
@@ -242,7 +242,7 @@ def test_design_matrix4():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Glover + Derivative'
+    hrf_model = 'glover + derivative'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                          drift_model='polynomial', drift_order=3)
     assert_equal(len(names), 10)
@@ -253,7 +253,7 @@ def test_design_matrix5():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = block_paradigm()
-    hrf_model = 'Glover'
+    hrf_model = 'glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                          drift_model='polynomial', drift_order=3)
     assert_equal(len(names), 7)
@@ -264,7 +264,7 @@ def test_design_matrix6():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = block_paradigm()
-    hrf_model = 'Glover + Derivative'
+    hrf_model = 'glover + derivative'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                          drift_model='polynomial', drift_order=3)
     assert_equal(len(names), 10)
@@ -279,7 +279,7 @@ def test_design_matrix7():
     onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
     paradigm = pd.DataFrame({'name': conditions,
                           'onset': onsets})
-    hrf_model = 'Glover'
+    hrf_model = 'glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                           drift_model='polynomial', drift_order=3)
     assert_equal(len(names), 7)
@@ -379,7 +379,7 @@ def test_design_matrix15():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Glover'
+    hrf_model = 'glover'
     ax = np.random.randn(128, 4)
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                          drift_model='polynomial', drift_order=3, add_regs=ax)
@@ -392,7 +392,7 @@ def test_design_matrix16():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Glover'
+    hrf_model = 'glover'
     ax = np.random.randn(128, 4)
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                          drift_model='polynomial', drift_order=3, add_regs=ax)
@@ -404,7 +404,7 @@ def test_design_matrix17():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = modulated_event_paradigm()
-    hrf_model = 'Glover'
+    hrf_model = 'glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                          drift_model='polynomial', drift_order=3)
     ct = paradigm.onset[paradigm.name == 'c0'].astype(np.int) + 1
@@ -416,7 +416,7 @@ def test_design_matrix18():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = modulated_block_paradigm()
-    hrf_model = 'Glover'
+    hrf_model = 'glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                          drift_model='polynomial', drift_order=3)
     ct = paradigm.onset[paradigm.name == 'c0'].astype(np.int) + 3
@@ -468,7 +468,7 @@ def test_csv_io():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = modulated_event_paradigm()
-    DM = make_design_matrix(frame_times, paradigm, hrf_model='Glover',
+    DM = make_design_matrix(frame_times, paradigm, hrf_model='glover',
                    drift_model='polynomial', drift_order=3)
     path = 'design_matrix.csv'
     with InTemporaryDirectory():

--- a/nistats/tests/test_dmtx.py
+++ b/nistats/tests/test_dmtx.py
@@ -43,7 +43,7 @@ DESIGN_MATRIX = np.load(full_path_design_matrix_file)
 
 
 def design_matrix_light(
-    frame_times, paradigm=None, hrf_model='canonical',
+    frame_times, paradigm=None, hrf_model='glover',
     drift_model='cosine', period_cut=128, drift_order=1, fir_delays=[0],
     add_regs=None, add_reg_names=None, min_onset=-24, path=None):
     """ Idem make_design_matrix, but only returns the computed matrix
@@ -160,11 +160,11 @@ def test_design_matrix0d():
 
 
 def test_design_matrix1():
-    # basic test based on basic_paradigm and canonical hrf
+    # basic test based on basic_paradigm and glover hrf
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Canonical'
+    hrf_model = 'glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                             drift_model='polynomial', drift_order=3)
     assert_equal(len(names), 7)
@@ -178,7 +178,7 @@ def test_convolve_regressors():
                           'onset': onsets})
     # names not passed -> default names
     frame_times = np.arange(100)
-    f, names = _convolve_regressors(paradigm, 'canonical', frame_times)
+    f, names = _convolve_regressors(paradigm, 'glover', frame_times)
     assert_equal(names, ['c0', 'c1'])
 
 
@@ -187,7 +187,7 @@ def test_design_matrix1b():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Canonical'
+    hrf_model = 'Glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                         drift_model='polynomial', drift_order=3)
     assert_equal(X.shape, (128, 7))
@@ -198,7 +198,7 @@ def test_design_matrix1c():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Canonical'
+    hrf_model = 'Glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                         drift_model='polynomial', drift_order=3)
     assert_true((X[:, - 1] == 1).all())
@@ -209,7 +209,7 @@ def test_design_matrix1d():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Canonical'
+    hrf_model = 'Glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                         drift_model='polynomial', drift_order=3)
     assert_true((np.isnan(X) == 0).all())
@@ -220,7 +220,7 @@ def test_design_matrix2():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Canonical'
+    hrf_model = 'Glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                         drift_model='cosine', period_cut=63)
     assert_equal(len(names), 7)  # was 8 with old cosine
@@ -231,7 +231,7 @@ def test_design_matrix3():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Canonical'
+    hrf_model = 'Glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                         drift_model='blank')
     assert_equal(len(names), 4)
@@ -242,7 +242,7 @@ def test_design_matrix4():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Canonical With Derivative'
+    hrf_model = 'Glover + Derivative'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                          drift_model='polynomial', drift_order=3)
     assert_equal(len(names), 10)
@@ -253,7 +253,7 @@ def test_design_matrix5():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = block_paradigm()
-    hrf_model = 'Canonical'
+    hrf_model = 'Glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                          drift_model='polynomial', drift_order=3)
     assert_equal(len(names), 7)
@@ -264,7 +264,7 @@ def test_design_matrix6():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = block_paradigm()
-    hrf_model = 'Canonical With Derivative'
+    hrf_model = 'Glover + Derivative'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                          drift_model='polynomial', drift_order=3)
     assert_equal(len(names), 10)
@@ -279,7 +279,7 @@ def test_design_matrix7():
     onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
     paradigm = pd.DataFrame({'name': conditions,
                           'onset': onsets})
-    hrf_model = 'Canonical'
+    hrf_model = 'Glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                           drift_model='polynomial', drift_order=3)
     assert_equal(len(names), 7)
@@ -379,7 +379,7 @@ def test_design_matrix15():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Canonical'
+    hrf_model = 'Glover'
     ax = np.random.randn(128, 4)
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                          drift_model='polynomial', drift_order=3, add_regs=ax)
@@ -392,7 +392,7 @@ def test_design_matrix16():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = basic_paradigm()
-    hrf_model = 'Canonical'
+    hrf_model = 'Glover'
     ax = np.random.randn(128, 4)
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                          drift_model='polynomial', drift_order=3, add_regs=ax)
@@ -404,7 +404,7 @@ def test_design_matrix17():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = modulated_event_paradigm()
-    hrf_model = 'Canonical'
+    hrf_model = 'Glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                          drift_model='polynomial', drift_order=3)
     ct = paradigm.onset[paradigm.name == 'c0'].astype(np.int) + 1
@@ -416,7 +416,7 @@ def test_design_matrix18():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = modulated_block_paradigm()
-    hrf_model = 'Canonical'
+    hrf_model = 'Glover'
     X, names = design_matrix_light(frame_times, paradigm, hrf_model=hrf_model,
                          drift_model='polynomial', drift_order=3)
     ct = paradigm.onset[paradigm.name == 'c0'].astype(np.int) + 3
@@ -441,7 +441,7 @@ def test_design_matrix20():
     frame_times = np.arange(0, 128)  # was 127 in old version of _cosine_drift
     paradigm = modulated_event_paradigm()
     X, names = design_matrix_light(
-        frame_times, paradigm, hrf_model='canonical', drift_model='cosine')
+        frame_times, paradigm, hrf_model='glover', drift_model='cosine')
 
     # check that the drifts are not constant
     assert_true(np.all(np.diff(X[:, -2]) != 0))
@@ -468,7 +468,7 @@ def test_csv_io():
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     paradigm = modulated_event_paradigm()
-    DM = make_design_matrix(frame_times, paradigm, hrf_model='Canonical',
+    DM = make_design_matrix(frame_times, paradigm, hrf_model='Glover',
                    drift_model='polynomial', drift_order=3)
     path = 'design_matrix.csv'
     with InTemporaryDirectory():

--- a/nistats/tests/test_dmtx.py
+++ b/nistats/tests/test_dmtx.py
@@ -120,11 +120,11 @@ def test_design_matrix0():
     # Test design matrix creation when no paradigm is provided
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
-
     _, X, names = check_design_matrix(make_design_matrix(
         frame_times, drift_model='polynomial', drift_order=3))
     assert_equal(len(names), 4)
-    assert_almost_equal(X[:, 0], np.linspace(- 0.5, .5, 128))
+    x = np.linspace(- 0.5, .5, 128)
+    assert_almost_equal(X[:, 0], x / np.linalg.norm(x))
 
 
 def test_design_matrix0c():

--- a/nistats/tests/test_dmtx.py
+++ b/nistats/tests/test_dmtx.py
@@ -124,7 +124,7 @@ def test_design_matrix0():
         frame_times, drift_model='polynomial', drift_order=3))
     assert_equal(len(names), 4)
     x = np.linspace(- 0.5, .5, 128)
-    assert_almost_equal(X[:, 0], x / np.linalg.norm(x))
+    assert_almost_equal(X[:, 0], x)
 
 
 def test_design_matrix0c():

--- a/nistats/tests/test_hemodynamic_models.py
+++ b/nistats/tests/test_hemodynamic_models.py
@@ -7,7 +7,7 @@ import warnings
 from nistats.hemodynamic_models import (
     spm_hrf, spm_time_derivative, spm_dispersion_derivative,
     _resample_regressor, _orthogonalize, _sample_condition,
-    _regressor_names, _hrf_kernel, glover_hrf,
+    _regressor_names, _hrf_kernel, glover_hrf, glover_dispersion_derivative,
     glover_time_derivative, compute_regressor)
 
 
@@ -36,6 +36,10 @@ def test_glover_hrf():
     h = glover_hrf(2.0)
     assert_almost_equal(h.sum(), 1)
     assert_equal(len(h), 256)
+    h = glover_dispersion_derivative(2.0)
+    assert_almost_equal(h.sum(), 0)
+    assert_equal(len(h), 256)
+
 
 
 def test_glover_time_derivative():
@@ -163,6 +167,8 @@ def test_names():
     assert_equal(_regressor_names(name, 'glover'), ['con'])
     assert_equal(_regressor_names(name, 'glover + derivative'),
         ['con', 'con_derivative'])
+    assert_equal(_regressor_names(name, 'glover + derivative + dispersion'),
+        ['con', 'con_derivative', 'con_dispersion'])
 
 
 def test_hkernel():

--- a/nistats/tests/test_hemodynamic_models.py
+++ b/nistats/tests/test_hemodynamic_models.py
@@ -156,11 +156,12 @@ def test_names():
     """
     name = 'con'
     assert_equal(_regressor_names(name, 'spm'), ['con'])
-    assert_equal(_regressor_names(name, 'spm_time'), ['con', 'con_derivative'])
-    assert_equal(_regressor_names(name, 'spm_time_dispersion'),
+    assert_equal(_regressor_names(name, 'spm + derivative'),
+                 ['con', 'con_derivative'])
+    assert_equal(_regressor_names(name, 'spm + derivative + dispersion'),
         ['con', 'con_derivative', 'con_dispersion'])
-    assert_equal(_regressor_names(name, 'canonical'), ['con'])
-    assert_equal(_regressor_names(name, 'canonical with derivative'),
+    assert_equal(_regressor_names(name, 'glover'), ['con'])
+    assert_equal(_regressor_names(name, 'glover + derivative'),
         ['con', 'con_derivative'])
 
 
@@ -171,16 +172,16 @@ def test_hkernel():
     h = _hrf_kernel('spm', tr)
     assert_almost_equal(h[0], spm_hrf(tr))
     assert_equal(len(h), 1)
-    h = _hrf_kernel('spm_time', tr)
+    h = _hrf_kernel('spm + derivative', tr)
     assert_almost_equal(h[1], spm_time_derivative(tr))
     assert_equal(len(h), 2)
-    h = _hrf_kernel('spm_time_dispersion', tr)
+    h = _hrf_kernel('spm + derivative + dispersion', tr)
     assert_almost_equal(h[2], spm_dispersion_derivative(tr))
     assert_equal(len(h), 3)
-    h = _hrf_kernel('canonical', tr)
+    h = _hrf_kernel('glover', tr)
     assert_almost_equal(h[0], glover_hrf(tr))
     assert_equal(len(h), 1)
-    h = _hrf_kernel('canonical with derivative', tr)
+    h = _hrf_kernel('glover + derivative', tr)
     assert_almost_equal(h[1], glover_time_derivative(tr))
     assert_almost_equal(h[0], glover_hrf(tr))
     assert_equal(len(h), 2)


### PR DESCRIPTION
This is an update of hrf module. Fixes a numerical issue, improves docstrings, adds  an example.
Addresses #36 and #34. 
The most debattable change is the removal of the name 'canonical' for the 'glover' hrf, because this name is unclear (in spm, the canonical hrf is not that one). This will break the compatibility with nipy.
What do people think about that ?