### PR TITLE
basic first level permutation tests

### DIFF
--- a/examples/plot_localizer_analysis_permutation.py
+++ b/examples/plot_localizer_analysis_permutation.py
@@ -1,0 +1,148 @@
+"""
+GLM fitting in fMRI
+===================
+
+Full step-by-step example of fitting a GLM to experimental data realizing
+permutation tests and visualizing the results.
+
+More specifically:
+
+1. A sequence of fMRI volumes are loaded
+2. A design matrix describing all the effects related to the data is computed
+3. a mask of the useful brain volume is computed
+4. A GLM is applied to the dataset (effect/covariance,
+   then contrast estimation)
+5. Permutation tests are performed to obtain uncorrected and corrected p values
+at each voxel for a contrast comparing only two conditions.
+
+"""
+
+print(__doc__)
+
+from os import mkdir, path
+
+import numpy as np
+import pandas as pd
+from nilearn import plotting
+
+from nistats.glm import FirstLevelGLM
+from nistats.design_matrix import make_design_matrix
+from nistats import datasets
+from nistats.permutation_tests import first_level_permutation_test
+from nistats.utils import z_score
+import nibabel as nib
+
+
+n_proc = 6
+
+### Data and analysis parameters #######################################
+
+# timing
+n_scans = 128
+tr = 2.4
+frame_times = np.linspace(0.5 * tr, (n_scans - .5) * tr, n_scans)
+
+# data
+data = datasets.fetch_localizer_first_level()
+paradigm_file = data.paradigm
+fmri_img = data.epi_img
+
+### Design matrix ########################################
+
+paradigm = pd.read_csv(paradigm_file, sep=' ', header=None, index_col=None)
+paradigm.columns = ['session', 'name', 'onset']
+design_matrix = make_design_matrix(
+    frame_times, paradigm, hrf_model='canonical with derivative',
+    drift_model="cosine", period_cut=128)
+
+### Perform a GLM analysis ########################################
+
+fmri_glm = FirstLevelGLM().fit(fmri_img, design_matrix)
+
+### Estimate contrasts #########################################
+
+# Specify the contrasts
+contrast_matrix = np.eye(design_matrix.shape[1])
+contrasts = dict([(column, contrast_matrix[i])
+                  for i, column in enumerate(design_matrix.columns)])
+
+contrasts["audio"] = contrasts["clicDaudio"] + contrasts["clicGaudio"] +\
+    contrasts["calculaudio"] + contrasts["phraseaudio"]
+contrasts["video"] = contrasts["clicDvideo"] + contrasts["clicGvideo"] + \
+    contrasts["calculvideo"] + contrasts["phrasevideo"]
+contrasts["computation"] = contrasts["calculaudio"] + contrasts["calculvideo"]
+contrasts["sentences"] = contrasts["phraseaudio"] + contrasts["phrasevideo"]
+
+# Short list or more relevant contrasts
+# contrasts = {
+#     "left-right": (contrasts["clicGaudio"] + contrasts["clicGvideo"]
+#                    - contrasts["clicDaudio"] - contrasts["clicDvideo"]),
+#     "H-V": contrasts["damier_H"] - contrasts["damier_V"],
+#     "audio-video": contrasts["audio"] - contrasts["video"],
+#     "video-audio": -contrasts["audio"] + contrasts["video"],
+#     "computation-sentences": (contrasts["computation"] -
+#                               contrasts["sentences"]),
+#     "reading-visual": contrasts["phrasevideo"] - contrasts["damier_H"]
+#     }
+
+contrasts = {
+    "reading-visual": contrasts["phrasevideo"] - contrasts["damier_H"]
+    }
+
+### Permutation tests ###########################################
+
+# Design matrix obj arrangement for paradigm permutations
+# What about creating design_matrix class to wrap make design matrix and
+# respective parameters. Then could just pass that object
+
+design_matrix_obj = [frame_times, paradigm,
+                     {'hrf_model': 'canonical with derivative',
+                      'drift_model': 'cosine',
+                      'period_cut': 128}]
+
+# Run the permutations
+
+res = first_level_permutation_test(contrasts, fmri_glm, fmri_img,
+                                   [design_matrix_obj], n_perm=600,
+                                   two_sided_test=True,
+                                   cluster_threshold=None,
+                                   random_state=None, verbose=10,
+                                   n_jobs=n_proc)
+
+### Plots #######################################################
+
+# Create snapshots of the contrasts thresholded with parametric and non
+# parametric methods.
+
+# write directory
+write_dir = 'results'
+if not path.exists(write_dir):
+    mkdir(write_dir)
+
+for index, (contrast_id, (unc_pval, cor_pval)) in enumerate(res.iteritems()):
+    z_map, = fmri_glm.transform(contrasts[contrast_id],
+                                contrast_name=contrast_id,
+                                output_z=True)
+    nib.save(z_map, path.join(write_dir, '%s_z_map.nii' % contrast_id))
+    z_map_data = fmri_glm.masker_.transform(z_map)[0]
+
+    display = plotting.plot_stat_map(z_map, display_mode='z',
+                                     threshold=z_score(0.1),
+                                     title=contrast_id)
+    display.savefig(path.join(write_dir, '%s_z_map.png' % contrast_id))
+
+    nib.save(unc_pval, path.join(write_dir, '%s_unc_pval.nii' % contrast_id))
+    nib.save(cor_pval, path.join(write_dir, '%s_cor_pval.nii' % contrast_id))
+
+    threshold = (fmri_glm.masker_.transform(unc_pval)[0] < 0.1)
+    thresholded_z_map = fmri_glm.masker_.inverse_transform(z_map_data * threshold)
+
+    display = plotting.plot_stat_map(thresholded_z_map, display_mode='z',
+                                     threshold=0.5, title=contrast_id)
+    display.savefig(path.join(write_dir, '%s_unc_pval.png' % contrast_id))
+
+    threshold = (fmri_glm.masker_.transform(cor_pval)[0] < 0.5)
+    thresholded_z_map = fmri_glm.masker_.inverse_transform(z_map_data * threshold)
+    display = plotting.plot_stat_map(thresholded_z_map, display_mode='z',
+                                     threshold=0.5, title=contrast_id)
+    display.savefig(path.join(write_dir, '%s_cor_pval.png' % contrast_id))

--- a/examples/plot_thresholding.py
+++ b/examples/plot_thresholding.py
@@ -1,0 +1,53 @@
+""" 
+Perform a one-sample t-test on a bunch of images (a.k.a. second-level analyis in fMRI) and threshold a statistical image.
+
+Author: Bertrand.thirion, Virgile Fritsch, 2014--2015
+"""
+print(__doc__)
+
+from nilearn import datasets
+from nilearn.input_data import NiftiMasker
+
+# Load some contrast images
+n_samples = 20
+localizer_dataset = datasets.fetch_localizer_calculation_task(
+    n_subjects=n_samples)
+
+# mask data
+nifti_masker = NiftiMasker(
+    smoothing_fwhm=5,
+    memory='nilearn_cache', memory_level=1)  # cache options
+cmap_filenames = localizer_dataset.cmaps
+fmri_masked = nifti_masker.fit_transform(cmap_filenames)
+
+# perform a one-sample test on these values
+from scipy.stats import ttest_1samp
+_, p_values = ttest_1samp(fmri_masked, 0)
+
+# z-transform of p-values
+from nistats.utils import z_score
+z_map = nifti_masker.inverse_transform(z_score(p_values))
+
+# Threshold the resulting map:
+# false positive rate < .001, cluster size > 10 voxels
+from nistats.thresholding import map_threshold
+thresholded_map1, threshold1 = map_threshold(
+    z_map, nifti_masker.mask_img_, threshold=.001, height_control='fpr',
+    cluster_threshold=10)
+
+# Now use FDR <.05, no cluster-level threshold
+thresholded_map2, threshold2 = map_threshold(
+    z_map, None, threshold=.05, height_control='fdr')
+
+
+# Visualization
+from nilearn import plotting
+display = plotting.plot_stat_map(z_map, title='Raw z map')
+plotting.plot_stat_map(
+    thresholded_map1, cut_coords=display.cut_coords, threshold=threshold1,
+    title='Thresholded z map, fpr <.001, clusters > 10 voxels')
+plotting.plot_stat_map(thresholded_map2, cut_coords=display.cut_coords,
+                       title='Thresholded z map, expected fdr = .05',
+                       threshold=threshold2)
+
+plotting.show()

--- a/nistats/permutation_tests.py
+++ b/nistats/permutation_tests.py
@@ -1,0 +1,296 @@
+"""
+Permutation tests for first level and second level analysis.
+"""
+# Author: Martin Perez-Guevara, <mperezguevara@gmail.com>, jan. 2016
+import warnings
+import numpy as np
+from sklearn.utils import check_random_state
+import sklearn.externals.joblib as joblib
+from sklearn.base import clone
+from nistats.design_matrix import make_design_matrix
+import time
+import sys
+
+
+def _meet_contrast_conditions(con_val):
+    """Check if permutation test is allowed for given contrast values."""
+    # No F tests
+    if type(con_val[0]) is list:
+        return False
+    # Not with less or more than 2 conditions
+    if len(np.where(con_val != 0.0)[0]) != 2:
+        return False
+    return True
+
+
+def _permutations_glm(original_stat, glm_ref, imgs, design_matrix_objs,
+                      con_val, con_id, con_labels, n_perm_chunk=10000,
+                      two_sided_test=True,
+                      random_state=None,
+                      n_perm=10000,
+                      thread_id=1,
+                      verbose=0):
+    """Massively univariate group analysis with permuted OLS on a data chunk.
+    To be used in a parallel computing context.
+    Parameters
+    ----------
+    design_matrix_objs: list of [time_frames, paradigm, kwargs dict].
+        frame_times is an array of shape (n_frames,) representing the timing
+        of the scans in seconds. Paradigm is a DataFrame instance with the
+        description of the experimental paradigm. kwargs are any other
+        arguments that could be passed to the function make_design_matrix
+        defined in nistats.design_matrix.
+
+    original_stat : array-like, shape=(n_voxels)
+        t-scores obtained for the original (non-permuted) data.
+
+    n_perm_chunk : int,
+        Number of permutations to be performed.
+
+    two_sided_test : boolean,
+        If True, performs an unsigned t-test. Both positive and negative
+        effects are considered; the null hypothesis is that the effect is zero.
+        If False, only positive effects are considered as relevant. The null
+        hypothesis is that the effect is zero or negative.
+
+    random_state : int or None,
+        Seed for random number generator, to have the same permutations
+        in each computing units.
+
+    Returns
+    -------
+    unc_ranks_parts: array-like, shape=(n_voxels)
+        Accumulated count of permuted stats over original stats,
+        to compute uncorrected p-values. (limited to this permutation chunk).
+
+    smax_parts : array-like, shape=(n_perm_chunk, )
+        Distribution of the (max) t-statistic under the null hypothesis
+        (limited to this permutation chunk).
+
+    References
+    ----------
+    [1] Nichols, T. E., & Holmes, A. P. (2002). Nonparametric permutation
+    tests for functional neuroimaging: a primer with examples. Human brain
+    mapping, 15(1), 1-25..
+    """
+    # initialize the seed of the random generator
+    rng = check_random_state(random_state)
+
+    # run the permutations
+    smax_parts = np.empty((n_perm_chunk))
+    unc_rank_parts = np.zeros(len(original_stat))
+    # Infer conditions to permute
+    conditions = np.where(con_val != 0.0)
+    t0 = time.time()
+    for i in range(n_perm_chunk):
+        # Shuffle labels of the conditions in the design matrix
+        design_matrices = []
+
+        for frame_times, paradigm, kwargs in design_matrix_objs:
+            perm_paradigm = paradigm.copy()
+            con_idx = np.where(con_val != 0.0)[0]
+            conditions = [con_labels[x] for x in con_idx]
+            selection = np.array([False for x in range(len(paradigm))])
+            for condition in conditions:
+                selection = selection | (perm_paradigm['name'] == condition)
+            sel_labels = perm_paradigm[selection]
+            labels_idx = sel_labels.index.tolist()
+            perm_labels = rng.permutation(sel_labels['name'].tolist())
+            for lidx, perm_label in zip(labels_idx, perm_labels):
+                perm_paradigm.loc[lidx, 'name'] = perm_label
+
+            design_matrices.append(make_design_matrix(frame_times,
+                                                      perm_paradigm,
+                                                      **kwargs))
+
+        # Get permuted stat
+        glm_obj = clone(glm_ref)
+        permuted_stat, = glm_obj.fit(imgs, design_matrices) \
+                                .transform(con_val, contrast_name=con_id,
+                                           output_z=False, output_stat=True)
+        permuted_stat = glm_obj.masker_.transform(permuted_stat)[0]
+
+        # For uncorrected p-values
+        if two_sided_test:
+            unc_rank_parts += (np.fabs(permuted_stat) < original_stat)
+        else:
+            unc_rank_parts += (permuted_stat < original_stat)
+
+        # For corrected p-values
+        smax_parts[i] = np.max(permuted_stat)
+
+        if verbose > 0:
+            # We print every 10 permutations or more often
+            step = 11 - min(verbose, 10)
+            if (i % step == 0):
+                # If there is only one job, progress information is fixed
+                if n_perm == n_perm_chunk:
+                    crlf = "\r"
+                else:
+                    crlf = "\n"
+                percent = float(i) / n_perm_chunk
+                percent = round(percent * 100, 2)
+                dt = time.time() - t0
+                # We use a max to avoid a division by zero
+                remaining = (100. - percent) / max(0.01, percent) * dt
+                sys.stderr.write(
+                    "Job #%d, processed %d/%d permutations for contrast %s "
+                    "(%0.2f%%, %i seconds remaining)%s"
+                    % (thread_id, i, n_perm_chunk, con_id, percent, remaining,
+                       crlf))
+
+    return unc_rank_parts, smax_parts
+
+
+def first_level_permutation_test(contrasts, glm_ref, imgs,
+                                 design_matrix_objs, n_perm=50,
+                                 two_sided_test=True, cluster_threshold=None,
+                                 random_state=None, verbose=1, n_jobs=1):
+    """Estimate uncorrected and FWE corrected p-values for voxel activation and
+    cluster size.
+
+    Parameters
+    ----------
+    contrasts: dict with string as key and list of float as value,
+        The key corresponds to the contrast name and the list size must
+        corresponds to the number of columns in the design matrices.
+        Currently only contrasts between two conditions can be computed.
+        So every contrast value must be of the form [...,+-1.,...,-+1.,...].
+        Contrasts considering more than two conditions will be ignored.
+
+    glm_ref: FirstLevelGLM instance,
+        To provide any GLM computation specification. This object will be
+        taken as a reference, new copies will the same parameters will be
+        created to be fitted on imgs and design_matrices.
+
+    imgs: Niimg-like object or list of Niimg-like objects,
+        See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
+        Data on which the GLM will be fitted. If this is a list,
+        the affine is considered the same for all.
+
+    design_matrix_objs: list of [time_frames, paradigm, kwargs dict].
+        frame_times is an array of shape (n_frames,) representing the timing
+        of the scans in seconds. Paradigm is a DataFrame instance with the
+        description of the experimental paradigm. kwargs are any other
+        arguments that could be passed to the function make_design_matrix
+        defined in nistats.design_matrix.
+
+    n_perm: int, optional
+        Number of permutations. Greater than 0. Defaults to 10000.
+
+    two_sided_test : boolean,
+        If True, performs an unsigned t-test. Both positive and negative
+        effects are considered; the null hypothesis is that the effect is zero.
+        If False, only positive effects are considered as relevant. The null
+        hypothesis is that the effect is zero or negative.
+
+    cluster_threshold: None or float, optional
+        Threshold for computation of cluster size statistics. If None will
+        not compute cluster size statistics.
+
+    n_jobs : integer, optional
+        The number of CPUs to use to do the computation. -1 means
+        'all CPUs', -2 'all CPUs but one', and so on.
+
+    verbose : integer, optional
+        Indicate the level of verbosity. By default, nothing is printed.
+
+    Returns
+    -------
+    contrast_results: dict with string as key and tuple of two Nifti1File
+        objects as value. The key is the contrast name and the first
+        nifti file contains the uncorrected p values derived from the
+        permutations at the voxel level, while the second nifti file contains
+        the corrected p values derived from the permutations whole brain max
+        statistic.
+    """
+    # check n_jobs (number of CPUs)
+    if n_jobs == 0:  # invalid according to joblib's conventions
+        raise ValueError("'n_jobs == 0' is not a valid choice. "
+                         "Please provide a positive number of CPUs, or -1 "
+                         "for all CPUs, or a negative number (-i) for "
+                         "'all but (i-1)' CPUs (joblib conventions).")
+    elif n_jobs < 0:
+        n_jobs = max(1, joblib.cpu_count() - int(n_jobs) + 1)
+    else:
+        n_jobs = min(n_jobs, joblib.cpu_count())
+
+    # Check n_perm
+    if n_perm <= 0:
+        raise ValueError("'n_perm <= 0' is not a valid choice.")
+
+    # Process one contrast at a time
+    contrast_results = {}
+    for (con_id, con_val) in contrasts.iteritems():
+        # Check permutation can be performed on contrasts
+        if not _meet_contrast_conditions(con_val):
+            warnings.warn('Contrast %s do not meet conditions.'
+                          'Computation ignored.' % (con_id,))
+            continue
+
+        # Get original stat
+        design_matrices = []
+        for time_frames, paradigm, kwargs in design_matrix_objs:
+            design_matrices.append(make_design_matrix(time_frames, paradigm,
+                                                      **kwargs))
+        glm_obj = clone(glm_ref)
+        original_stat, = glm_obj.fit(imgs, design_matrices) \
+                                .transform(con_val, contrast_name=con_id,
+                                           output_z=False, output_stat=True)
+        original_stat = glm_obj.masker_.transform(original_stat)[0]
+        if two_sided_test:
+            original_stat = np.fabs(original_stat)
+        # Check possible permutations
+
+        # Distribute permutations across jobs
+        if n_perm > n_jobs:
+            n_perm_chunks = np.asarray([n_perm / n_jobs] * n_jobs,
+                                       dtype=int)
+            n_perm_chunks[-1] += n_perm % n_jobs
+        elif n_perm > 0:
+            warnings.warn('The specified number of permutations is %d and '
+                          'the number of jobs to be performed in parallel was '
+                          'set to %s. This is incompatible so only %d jobs will '
+                          'be running. You may want to perform more permutations '
+                          'in order to take the most of the available computing '
+                          'resources.' % (n_perm, n_jobs, n_perm))
+            n_perm_chunks = np.ones(n_perm, dtype=int)
+
+        # initialize the seed of the random generator
+        rng = check_random_state(random_state)
+
+        per = joblib.Parallel(n_jobs=n_jobs, verbose=verbose)(
+              joblib.delayed(_permutations_glm)(
+                  original_stat, glm_ref, imgs, design_matrix_objs,
+                  con_val, con_id, design_matrices[0].columns.tolist(),
+                  n_perm_chunk=n_perm_chunk,
+                  two_sided_test=two_sided_test,
+                  random_state=rng.random_integers(np.iinfo(np.int32).max - 1),
+                  n_perm=n_perm, thread_id=thread_id, verbose=verbose)
+              for thread_id, n_perm_chunk in enumerate(n_perm_chunks))
+
+        unc_ranks_parts, smax_parts = zip(*per)
+        # Get uncorrected p-values
+        unc_ranks = np.zeros(len(original_stat))
+        for unc_ranks_part in unc_ranks_parts:
+            unc_ranks += unc_ranks_part
+        unc_pvals = (n_perm + 1 - unc_ranks) / float(1 + n_perm)
+        # Get corrected p-values
+        smax = np.concatenate(smax_parts)
+        cor_ranks = np.zeros(len(original_stat))
+        if two_sided_test:
+            for s in np.fabs(smax):
+                cor_ranks += (s < original_stat)
+        else:
+            for s in smax:
+                cor_ranks += (s < original_stat)
+
+        cor_pvals = (n_perm + 1 - cor_ranks) / float(1 + n_perm)
+
+        unc_pvals = glm_obj.masker_.inverse_transform(unc_pvals)
+        cor_pvals = glm_obj.masker_.inverse_transform(cor_pvals)
+
+        contrast_results[con_id] = (unc_pvals,
+                                    cor_pvals)
+
+    return contrast_results

--- a/nistats/tests/test_dmtx.py
+++ b/nistats/tests/test_dmtx.py
@@ -1,5 +1,3 @@
-# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
-# vi: set ft=python sts=4 ts=4 sw=4 et:
 """
 Test the design_matrix utilities.
 
@@ -11,11 +9,13 @@ from __future__ import with_statement
 
 import numpy as np
 import os.path as osp
-from ..design_matrix import (
+import pandas as pd
+
+from nistats.design_matrix import (
     _convolve_regressors, make_design_matrix,
     _cosine_drift, plot_design_matrix, check_design_matrix)
-import pandas as pd
-from ..experimental_paradigm import check_paradigm
+
+from nistats.experimental_paradigm import check_paradigm
 
 from nibabel.tmpdirs import InTemporaryDirectory
 

--- a/nistats/tests/test_glm.py
+++ b/nistats/tests/test_glm.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from nibabel import load, Nifti1Image, save
 
-from ..glm import (
+from nistats.glm import (
     percent_mean_scaling, session_glm, FirstLevelGLM, compute_contrast)
 
 from nose.tools import assert_true, assert_equal, assert_raises

--- a/nistats/tests/test_hemodynamic_models.py
+++ b/nistats/tests/test_hemodynamic_models.py
@@ -4,7 +4,7 @@ from numpy.testing import (
     assert_almost_equal, assert_equal, assert_array_equal, assert_warns)
 import warnings
 
-from ..hemodynamic_models import (
+from nistats.hemodynamic_models import (
     spm_hrf, spm_time_derivative, spm_dispersion_derivative,
     _resample_regressor, _orthogonalize, _sample_condition,
     _regressor_names, _hrf_kernel, glover_hrf,

--- a/nistats/tests/test_model.py
+++ b/nistats/tests/test_model.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 # In fact we're testing methods defined in model
-from ..regression import OLSModel
+from nistats.regression import OLSModel
 
 from nose.tools import assert_true, assert_equal, assert_raises
 from nose import SkipTest

--- a/nistats/tests/test_paradigm.py
+++ b/nistats/tests/test_paradigm.py
@@ -1,5 +1,3 @@
-# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
-# vi: set ft=python sts=4 ts=4 sw=4 et:
 """
 Test the design_matrix utilities.
 
@@ -9,8 +7,10 @@ not whether it is exact.
 
 import numpy as np
 import os
-import pandas  as pd
-from ..experimental_paradigm import check_paradigm, paradigm_from_csv
+import pandas as pd
+
+from nistats.experimental_paradigm import paradigm_from_csv
+
 from nose.tools import assert_true
 
 

--- a/nistats/tests/test_regression.py
+++ b/nistats/tests/test_regression.py
@@ -1,12 +1,10 @@
-# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
-# vi: set ft=python sts=4 ts=4 sw=4 et:
 """
 Test functions for models.regression
 """
 
 import numpy as np
 
-from ..regression import OLSModel, ARModel
+from nistats.regression import OLSModel, ARModel
 
 from nose.tools import assert_equal, assert_true
 from numpy.testing import assert_array_almost_equal, assert_array_equal

--- a/nistats/tests/test_thresholding.py
+++ b/nistats/tests/test_thresholding.py
@@ -1,0 +1,72 @@
+""" Test the thresholding utilities
+"""
+import numpy as np
+from scipy.stats import norm
+from nose.tools import assert_true
+from numpy.testing import assert_almost_equal, assert_equal
+import nibabel as nib
+from nistats.thresholding import (fdr_threshold, map_threshold)
+
+
+def test_fdr():
+    n = 100
+    x = np.linspace(.5 / n, 1. - .5 / n, n)
+    x[:10] = .0005
+    x = norm.isf(x)
+    np.random.shuffle(x)
+    assert_almost_equal(fdr_threshold(x, .1), norm.isf(.0005))
+    assert_true(fdr_threshold(x, .001) == np.infty)
+
+
+def test_map_threshold():
+    shape = (9, 10, 11)
+    p = np.prod(shape)
+    data = norm.isf(np.linspace(1. / p, 1. - 1. / p, p)).reshape(shape)
+    threshold = .001
+    data[2:4, 5:7, 6:8] = 5.
+    stat_img = nib.Nifti1Image(data, np.eye(4))
+    mask_img = nib.Nifti1Image(np.ones(shape), np.eye(4))
+
+    # test 1
+    th_map, _ = map_threshold(
+        stat_img, mask_img, threshold, height_control='fpr',
+        cluster_threshold=0)
+    vals = th_map.get_data()
+    assert_equal(np.sum(vals > 0), 8)
+
+    # test 2: excessive cluster forming threshold
+    th_map, _ = map_threshold(
+        stat_img, mask_img, 100, height_control=None,
+        cluster_threshold=0)
+    vals = th_map.get_data()
+    assert_true(np.sum(vals > 0) == 0)
+
+    # test 3:excessive size threshold
+    th_map, z_th = map_threshold(
+        stat_img, mask_img, threshold, height_control='fpr',
+        cluster_threshold=10)
+    vals = th_map.get_data()
+    assert_true(np.sum(vals > 0) == 0)
+    assert_equal(z_th, norm.isf(.001))
+
+    # test 4: fdr threshold + bonferroni
+    for control in ['fdr', 'bonferroni']:
+        th_map, _ = map_threshold(
+            stat_img, mask_img, .05, height_control=control,
+            cluster_threshold=5)
+        vals = th_map.get_data()
+        assert_equal(np.sum(vals > 0), 8)
+
+    # test 5: direct threshold
+    th_map, _ = map_threshold(
+        stat_img, mask_img, 4.0, height_control=None,
+        cluster_threshold=0)
+    vals = th_map.get_data()
+    assert_equal(np.sum(vals > 0), 8)
+
+    # test 6: without mask
+    th_map, _ = map_threshold(
+        stat_img, None, 4.0, height_control=None,
+        cluster_threshold=0)
+    vals = th_map.get_data()
+    assert_equal(np.sum(vals > 0), 8)

--- a/nistats/tests/test_utils.py
+++ b/nistats/tests/test_utils.py
@@ -6,7 +6,7 @@ import scipy.linalg as spl
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
 from nose.tools import assert_true, assert_equal
 
-from ..utils import (multiple_mahalanobis, z_score, multiple_fast_inv,
+from nistats.utils import (multiple_mahalanobis, z_score, multiple_fast_inv,
                      pos_recipr, full_rank)
 
 

--- a/nistats/thresholding.py
+++ b/nistats/thresholding.py
@@ -1,0 +1,85 @@
+""" Utilities to describe the result of cluster-level analysis of statistical
+maps.
+
+Author: Bertrand Thirion, 2015
+"""
+import numpy as np
+from scipy.ndimage import label
+from scipy.stats import norm
+from nilearn.input_data import NiftiMasker
+
+
+def fdr_threshold(z_vals, alpha):
+    """ return the BH fdr for the input z_vals"""
+    z_vals_ = - np.sort(- z_vals)
+    p_vals = norm.sf(z_vals_)
+    n_samples = len(p_vals)
+    pos = p_vals < alpha * np.linspace(
+        .5 / n_samples, 1 - .5 / n_samples, n_samples)
+    if pos.any():
+        return (z_vals_[pos][-1] - 1.e-8)
+    else:
+        return np.infty
+
+
+def map_threshold(stat_img, mask_img=None, threshold=.001,
+                  height_control='fpr', cluster_threshold=0):
+    """ Threshold the provided map
+
+    Parameters
+    ----------
+    stat_img : Niimg-like object,
+       statistical image (presumably in z scale)
+
+    mask_img : Niimg-like object, optional,
+        mask image
+
+    threshold: float, optional
+        cluster forming threshold (either a p-value or z-scale value)
+
+    height_control: string, optional
+        false positive control meaning of cluster forming
+        threshold: 'fpr'|'fdr'|'bonferroni'|'none'
+
+    cluster_threshold : float, optional
+        cluster size threshold
+
+    Returns
+    -------
+    thresholded_map : Nifti1Image,
+        the stat_map theresholded at the prescribed voxel- and cluster-level
+        
+    threshold: float,
+        the voxel-level threshold used actually
+    """
+    # Masking
+    if mask_img is None:
+        masker = NiftiMasker(mask_strategy='background').fit(stat_img)
+    else:
+        masker = NiftiMasker(mask_img=mask_img).fit()
+    stats = np.ravel(masker.transform(stat_img))
+    n_voxels = np.size(stats)
+
+    # Thresholding
+    if height_control == 'fpr':
+        z_th = norm.isf(threshold)
+    elif height_control == 'fdr':
+        z_th = fdr_threshold(stats, threshold)
+    elif height_control == 'bonferroni':
+        z_th = norm.isf(threshold / n_voxels)
+    else:  # Brute-force thresholding
+        z_th = threshold
+    stats *= (stats > z_th)
+
+    # embed it back to 3D grid
+    stat_map = masker.inverse_transform(stats).get_data()
+
+    # Extract connected components above threshold
+    label_map, n_labels = label(stat_map > z_th)
+    labels = label_map[masker.mask_img_.get_data() > 0]
+
+    for label_ in range(1, n_labels + 1):
+        if np.sum(labels == label_) < cluster_threshold:
+            stats[labels == label_] = 0
+
+    return masker.inverse_transform(stats), z_th


### PR DESCRIPTION
Here I provide the localizer example modified to perform basic contrasts first level permutation tests. I also provide an initial proposal for a permutation API. I am convinced this API is far from optimal, particularly I find cumbersome the way I am passing the design matrix objs to the permutation test. I would support #40, since I think having a design matrix object would allow me to pass it and access all relevant information from it as I do from the FirstLevelGLM object.

I am not sure on what would be the appropriate way to write tests for this functionality. In any case first eye tests seem nice. Following we can see the comparison between the original z score map for the contrast reading-visual for uncorrected p<0.1, then the permuted version for uncorrected p<0.1 and finally the permuted version for corrected p<0.5. The correction is very strong. 600 permutations were performed.

![reading-visual_z_map](https://cloud.githubusercontent.com/assets/8766915/12727625/072d823e-c91e-11e5-910b-acbccc750518.png)

![reading-visual_unc_pval](https://cloud.githubusercontent.com/assets/8766915/12727694/59534bca-c91e-11e5-80c7-9ea7d708fa03.png)

![reading-visual_cor_pval](https://cloud.githubusercontent.com/assets/8766915/12727704/63e4048a-c91e-11e5-8eaf-4fbc7306effe.png)
