### PR TITLE
Bids utilities

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,6 +25,9 @@
 .. |second_level| image:: auto_examples/images/thumb/sphx_glr_plot_second_level_button_press_thumb.png
      :target: auto_examples/plot_second_level_button_press.html
 
+.. |bids| image:: auto_examples/images/thumb/sphx_glr_plot_bids_analysis_thumb.png
+     :target: auto_examples/plot_bids_analysis.html
+
 
 .. raw:: html
 
@@ -46,6 +49,8 @@
 * |first_level|
 
 * |second_level|
+
+* |bids|
 
 
 .. raw:: html

--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -27,6 +27,8 @@ uses.
    :toctree: generated/
    :template: function.rst
 
+   fetch_bids_langloc_dataset
+   fetch_bids_openfmri_dataset
    fetch_localizer_first_level
    fetch_spm_auditory
    fetch_spm_multimodal_fmri
@@ -171,6 +173,7 @@ uses.
 
    mean_scaling
    run_glm
+   first_level_models_from_bids
 
 .. _second_level_model_ref:
 
@@ -262,3 +265,5 @@ uses.
    multiple_mahalanobis
    full_rank
    pos_recipr
+   get_bids_files
+   parse_bids_filename

--- a/doc/themes/nistats/layout.html
+++ b/doc/themes/nistats/layout.html
@@ -154,6 +154,9 @@ $(function () {
     <li>
       <big><a href="{{pathto('auto_examples/plot_second_level_button_press')}}">Second Level</a></big>
     </li>
+    <li>
+      <big><a href="{{pathto('auto_examples/plot_bids_analysis')}}">BIDS datasets</a></big>
+    </li>
   </ul>
  </div>
 

--- a/examples/plot_bids_analysis.py
+++ b/examples/plot_bids_analysis.py
@@ -16,6 +16,7 @@ More specifically:
 
 Author : Martin Perez-Guevara: 2016
 """
+
 import os
 from nilearn import plotting
 from scipy.stats import norm
@@ -25,7 +26,7 @@ from nistats.datasets import fetch_bids_langloc_dataset
 from nistats.first_level_model import first_level_models_from_bids
 from nistats.second_level_model import SecondLevelModel
 
-#############################################################################
+##############################################################################
 # Fetch example BIDS dataset
 # --------------------------
 # We download a partial example BIDS dataset. It contains only the necessary
@@ -35,7 +36,7 @@ from nistats.second_level_model import SecondLevelModel
 # confounds.tsv files.
 data_dir, _ = fetch_bids_langloc_dataset()
 
-#############################################################################
+##############################################################################
 # Obtain automatically FirstLevelModel objects and fit arguments
 # --------------------------------------------------------------
 # From the dataset directory we obtain automatically FirstLevelModel objects
@@ -59,7 +60,7 @@ models, m_run_imgs, m_events, m_confounds = first_level_models_from_bids(
 # We just expect one run img per subject.
 print([os.path.basename(run) for run in m_run_imgs[0]])
 
-##############################################################################
+###############################################################################
 # The only confounds stored are regressors obtained from motion correction. As
 # we can verify from the column headers of the confounds table corresponding
 # to the only run_img present

--- a/examples/plot_bids_analysis.py
+++ b/examples/plot_bids_analysis.py
@@ -85,7 +85,7 @@ for midx, (model, model_kwargs) in enumerate(zip(models, fit_kwargs)):
     plotting.plot_glass_brain(zmap, colorbar=False, threshold=norm.isf(0.001),
                               title=('sub-' + model.subject_label),
                               axes=axes[midx / 5, midx % 5],
-                              plot_abs=False, display_mode='l')
+                              plot_abs=False, display_mode='x')
 fig.suptitle('subjects z_map language netowrk (language - string)')
 plt.show()
 
@@ -110,5 +110,5 @@ zmap = second_level_model.compute_contrast('language-string')
 # lateralized as expected
 plotting.plot_glass_brain(zmap, colorbar=False, threshold=norm.isf(0.001),
                           title='Group language network',
-                          plot_abs=False, display_mode='lr')
+                          plot_abs=False, display_mode='x')
 plotting.show()

--- a/examples/plot_bids_analysis.py
+++ b/examples/plot_bids_analysis.py
@@ -44,12 +44,12 @@ data_dir, _ = fetch_bids_langloc_dataset()
 # for each model a dictionary with run_imgs, events and confounder regressors
 # since in this case a confounds.tsv file is available in the BIDS dataset.
 # To get the first level models we only have to specify the dataset directory
-# and the task_id as specified in the file names.
-task_id = 'languagelocalizer'
+# and the task_label as specified in the file names.
+task_label = 'languagelocalizer'
 models, models_run_imgs, models_events, models_confounds = \
     first_level_models_from_bids(
-        data_dir, task_id, preproc_space='MNI152nonlin2009aAsym',
-        preproc_variant='smoothResamp')
+        data_dir, task_label, space_label='MNI152nonlin2009aAsym',
+        [('variant', 'smoothResamp')])
 
 #############################################################################
 # Quick sanity check on fit arguments

--- a/examples/plot_bids_analysis.py
+++ b/examples/plot_bids_analysis.py
@@ -46,9 +46,10 @@ data_dir, _ = fetch_bids_langloc_dataset()
 # To get the first level models we only have to specify the dataset directory
 # and the task_id as specified in the file names.
 task_id = 'languagelocalizer'
-models, m_run_imgs, m_events, m_confounds = first_level_models_from_bids(
-    data_dir, task_id, preproc_space='MNI152nonlin2009aAsym',
-    preproc_variant='smoothResamp')
+models, models_run_imgs, models_events, models_confounds = \
+    first_level_models_from_bids(
+        data_dir, task_id, preproc_space='MNI152nonlin2009aAsym',
+        preproc_variant='smoothResamp')
 
 #############################################################################
 # Quick sanity check on fit arguments
@@ -58,19 +59,19 @@ models, m_run_imgs, m_events, m_confounds = first_level_models_from_bids(
 
 ############################################################################
 # We just expect one run img per subject.
-print([os.path.basename(run) for run in m_run_imgs[0]])
+print([os.path.basename(run) for run in models_run_imgs[0]])
 
 ###############################################################################
 # The only confounds stored are regressors obtained from motion correction. As
 # we can verify from the column headers of the confounds table corresponding
 # to the only run_img present
-print(m_confounds[0][0].columns)
+print(models_confounds[0][0].columns)
 
 ############################################################################
 # During this acquisition the subject read blocks of sentences and
 # consonant strings. So these are our only two conditions in events.
 # We verify there are n blocks for each condition.
-print(m_events[0][0]['trial_type'].value_counts())
+print(models_events[0][0]['trial_type'].value_counts())
 
 ############################################################################
 # First level model estimation
@@ -78,7 +79,7 @@ print(m_events[0][0]['trial_type'].value_counts())
 # Now we simply fit each first level model and plot for each subject the
 # contrast that reveals the language network (language - string).
 fig, axes = plt.subplots(nrows=2, ncols=5)
-model_and_args = zip(models, m_run_imgs, m_events, m_confounds)
+model_and_args = zip(models, models_run_imgs, models_events, models_confounds)
 for midx, (model, imgs, events, confounds) in enumerate(model_and_args):
     model.fit(imgs, events, confounds)
     zmap = model.compute_contrast('language-string')
@@ -86,7 +87,7 @@ for midx, (model, imgs, events, confounds) in enumerate(model_and_args):
                               title=('sub-' + model.subject_label),
                               axes=axes[int(midx / 5), int(midx % 5)],
                               plot_abs=False, display_mode='x')
-fig.suptitle('subjects z_map language network (language - string)')
+fig.suptitle('subjects z_map language network (unc p<0.001)')
 plt.show()
 
 #########################################################################
@@ -109,6 +110,6 @@ zmap = second_level_model.compute_contrast('language-string')
 # The group level contrast of the language network is mostly left
 # lateralized as expected
 plotting.plot_glass_brain(zmap, colorbar=True, threshold=norm.isf(0.001),
-                          title='Group language network',
+                          title='Group language network (unc p<0.001)',
                           plot_abs=False, display_mode='x')
 plotting.show()

--- a/examples/plot_bids_analysis.py
+++ b/examples/plot_bids_analysis.py
@@ -84,7 +84,7 @@ for midx, (model, imgs, events, confounds) in enumerate(model_and_args):
     zmap = model.compute_contrast('language-string')
     plotting.plot_glass_brain(zmap, colorbar=False, threshold=norm.isf(0.001),
                               title=('sub-' + model.subject_label),
-                              axes=axes[midx / 5, midx % 5],
+                              axes=axes[int(midx / 5), int(midx % 5)],
                               plot_abs=False, display_mode='x')
 fig.suptitle('subjects z_map language network (language - string)')
 plt.show()

--- a/examples/plot_bids_analysis.py
+++ b/examples/plot_bids_analysis.py
@@ -46,10 +46,11 @@ data_dir, _ = fetch_bids_langloc_dataset()
 # To get the first level models we only have to specify the dataset directory
 # and the task_label as specified in the file names.
 task_label = 'languagelocalizer'
+space_label = 'MNI152nonlin2009aAsym'
 models, models_run_imgs, models_events, models_confounds = \
     first_level_models_from_bids(
-        data_dir, task_label, space_label='MNI152nonlin2009aAsym',
-        [('variant', 'smoothResamp')])
+        data_dir, task_label, space_label,
+        img_filters=[('variant', 'smoothResamp')])
 
 #############################################################################
 # Quick sanity check on fit arguments

--- a/examples/plot_bids_analysis.py
+++ b/examples/plot_bids_analysis.py
@@ -4,13 +4,13 @@ BIDS dataset first and second level analysis
 
 Full step-by-step example of fitting a GLM to perform a first and second level
 analysis in a BIDS dataset and visualizing the results. Details about the BIDS
-standard can be consulted at https://openfmri.org/data-organization/
+standard can be consulted at http://bids.neuroimaging.io/
 
 More specifically:
 
 1. Download an fMRI BIDS dataset with two language conditions to contrast.
-2. We extract automatically from the BIDS dataset first level model objects
-3. We fit a second level model on the fitted first level models. Notice that
+2. Extract automatically from the BIDS dataset first level model objects
+3. Fit a second level model on the fitted first level models. Notice that
    in this case the preprocessed bold images were already normalized to the
    same MNI space.
 
@@ -29,7 +29,7 @@ from nistats.second_level_model import SecondLevelModel
 # Fetch example BIDS dataset
 # --------------------------
 # We download a partial example BIDS dataset. It contains only the necessary
-# information to run an statistical analysis using Nistats. The raw data
+# information to run a statistical analysis using Nistats. The raw data
 # subject folders only contain bold.json and events.tsv files, while the
 # derivatives folder with preprocessed files contain preproc.nii and
 # confounds.tsv files.
@@ -45,33 +45,31 @@ data_dir, _ = fetch_bids_langloc_dataset()
 # To get the first level models we only have to specify the dataset directory
 # and the task_id as specified in the file names.
 task_id = 'languagelocalizer'
-models, fit_kwargs = first_level_models_from_bids(
+models, m_run_imgs, m_events, m_confounds = first_level_models_from_bids(
     data_dir, task_id, preproc_space='MNI152nonlin2009aAsym',
     preproc_variant='smoothResamp')
 
 #############################################################################
 # Quick sanity check on fit arguments
 # -----------------------------------
-# Normally you might want to do some additional processing on event files
-# or you might want to create or extend confound regressors. In this example
-# dataset none of that is necessary, so we will just go through the
-# experimental paradigm and check all is fine for the first subject.
+# Additional checks or information extraction from pre-processed data can
+# be made here
 
 ############################################################################
 # We just expect one run img per subject.
-print([os.path.basename(run) for run in fit_kwargs[0]['run_imgs']])
+print([os.path.basename(run) for run in m_run_imgs[0]])
 
 ##############################################################################
 # The only confounds stored are regressors obtained from motion correction. As
 # we can verify from the column headers of the confounds table corresponding
 # to the only run_img present
-print(fit_kwargs[0]['confounds'][0].columns)
+print(m_confounds[0][0].columns)
 
 ############################################################################
 # During this acquisition the subject read blocks of sentences and
 # consonant strings. So these are our only two conditions in events.
 # We verify there are n blocks for each condition.
-print(fit_kwargs[0]['events'][0]['trial_type'].value_counts())
+print(m_events[0][0]['trial_type'].value_counts())
 
 ############################################################################
 # First level model estimation
@@ -79,14 +77,15 @@ print(fit_kwargs[0]['events'][0]['trial_type'].value_counts())
 # Now we simply fit each first level model and plot for each subject the
 # contrast that reveals the language network (language - string).
 fig, axes = plt.subplots(nrows=2, ncols=5)
-for midx, (model, model_kwargs) in enumerate(zip(models, fit_kwargs)):
-    model.fit(**model_kwargs)
+model_and_args = zip(models, m_run_imgs, m_events, m_confounds)
+for midx, (model, imgs, events, confounds) in enumerate(model_and_args):
+    model.fit(imgs, events, confounds)
     zmap = model.compute_contrast('language-string')
     plotting.plot_glass_brain(zmap, colorbar=False, threshold=norm.isf(0.001),
                               title=('sub-' + model.subject_label),
                               axes=axes[midx / 5, midx % 5],
                               plot_abs=False, display_mode='x')
-fig.suptitle('subjects z_map language netowrk (language - string)')
+fig.suptitle('subjects z_map language network (language - string)')
 plt.show()
 
 #########################################################################
@@ -108,7 +107,7 @@ zmap = second_level_model.compute_contrast('language-string')
 #########################################################################
 # The group level contrast of the language network is mostly left
 # lateralized as expected
-plotting.plot_glass_brain(zmap, colorbar=False, threshold=norm.isf(0.001),
+plotting.plot_glass_brain(zmap, colorbar=True, threshold=norm.isf(0.001),
                           title='Group language network',
                           plot_abs=False, display_mode='x')
 plotting.show()

--- a/examples/plot_bids_analysis.py
+++ b/examples/plot_bids_analysis.py
@@ -16,7 +16,6 @@ More specifically:
 
 Author : Martin Perez-Guevara: 2016
 """
-import pandas as pd
 import os
 from nilearn import plotting
 from scipy.stats import norm
@@ -32,7 +31,7 @@ from nistats.second_level_model import SecondLevelModel
 # We download a partial example BIDS dataset. It contains only the necessary
 # information to run an statistical analysis using Nistats. The raw data
 # subject folders only contain bold.json and events.tsv files, while the
-# derivatives folder with preprocessed files contain preproc.nii and 
+# derivatives folder with preprocessed files contain preproc.nii and
 # confounds.tsv files.
 data_dir, _ = fetch_bids_langloc_dataset()
 
@@ -84,11 +83,11 @@ for midx, (model, model_kwargs) in enumerate(zip(models, fit_kwargs)):
     model.fit(**model_kwargs)
     zmap = model.compute_contrast('language-string')
     plotting.plot_glass_brain(zmap, colorbar=False, threshold=norm.isf(0.001),
-                              title=('sub-' + model.subject_id),
+                              title=('sub-' + model.subject_label),
                               axes=axes[midx / 5, midx % 5],
                               plot_abs=False, display_mode='l')
 fig.suptitle('subjects z_map language netowrk (language - string)')
-fig.show()
+plt.show()
 
 #########################################################################
 # Second level model estimation

--- a/examples/plot_bids_analysis.py
+++ b/examples/plot_bids_analysis.py
@@ -1,0 +1,115 @@
+"""
+BIDS dataset first and second level analysis
+============================================
+
+Full step-by-step example of fitting a GLM to perform a first and second level
+analysis in a BIDS dataset and visualizing the results. Details about the BIDS
+standard can be consulted at https://openfmri.org/data-organization/
+
+More specifically:
+
+1. Download an fMRI BIDS dataset with two language conditions to contrast.
+2. We extract automatically from the BIDS dataset first level model objects
+3. We fit a second level model on the fitted first level models. Notice that
+   in this case the preprocessed bold images were already normalized to the
+   same MNI space.
+
+Author : Martin Perez-Guevara: 2016
+"""
+import pandas as pd
+import os
+from nilearn import plotting
+from scipy.stats import norm
+import matplotlib.pyplot as plt
+
+from nistats.datasets import fetch_bids_langloc_dataset
+from nistats.first_level_model import first_level_models_from_bids
+from nistats.second_level_model import SecondLevelModel
+
+#############################################################################
+# Fetch example BIDS dataset
+# --------------------------
+# We download a partial example BIDS dataset. It contains only the necessary
+# information to run an statistical analysis using Nistats. The raw data
+# subject folders only contain bold.json and events.tsv files, while the
+# derivatives folder with preprocessed files contain preproc.nii and 
+# confounds.tsv files.
+data_dir, _ = fetch_bids_langloc_dataset()
+
+#############################################################################
+# Obtain automatically FirstLevelModel objects and fit arguments
+# --------------------------------------------------------------
+# From the dataset directory we obtain automatically FirstLevelModel objects
+# with their subject_id filled from the BIDS dataset. Moreover we obtain
+# for each model a dictionary with run_imgs, events and confounder regressors
+# since in this case a confounds.tsv file is available in the BIDS dataset.
+# To get the first level models we only have to specify the dataset directory
+# and the task_id as specified in the file names.
+task_id = 'languagelocalizer'
+models, fit_kwargs = first_level_models_from_bids(
+    data_dir, task_id, preproc_space='MNI152nonlin2009aAsym',
+    preproc_variant='smoothResamp')
+
+#############################################################################
+# Quick sanity check on fit arguments
+# -----------------------------------
+# Normally you might want to do some additional processing on event files
+# or you might want to create or extend confound regressors. In this example
+# dataset none of that is necessary, so we will just go through the
+# experimental paradigm and check all is fine for the first subject.
+
+############################################################################
+# We just expect one run img per subject.
+print([os.path.basename(run) for run in fit_kwargs[0]['run_imgs']])
+
+##############################################################################
+# The only confounds stored are regressors obtained from motion correction. As
+# we can verify from the column headers of the confounds table corresponding
+# to the only run_img present
+print(fit_kwargs[0]['confounds'][0].columns)
+
+############################################################################
+# During this acquisition the subject read blocks of sentences and
+# consonant strings. So these are our only two conditions in events.
+# We verify there are n blocks for each condition.
+print(fit_kwargs[0]['events'][0]['trial_type'].value_counts())
+
+############################################################################
+# First level model estimation
+# ----------------------------
+# Now we simply fit each first level model and plot for each subject the
+# contrast that reveals the language network (language - string).
+fig, axes = plt.subplots(nrows=2, ncols=5)
+for midx, (model, model_kwargs) in enumerate(zip(models, fit_kwargs)):
+    model.fit(**model_kwargs)
+    zmap = model.compute_contrast('language-string')
+    plotting.plot_glass_brain(zmap, colorbar=False, threshold=norm.isf(0.001),
+                              title=('sub-' + model.subject_id),
+                              axes=axes[midx / 5, midx % 5],
+                              plot_abs=False, display_mode='l')
+fig.suptitle('subjects z_map language netowrk (language - string)')
+fig.show()
+
+#########################################################################
+# Second level model estimation
+# -----------------------------
+# We just have to provide the list of fitted FirstLevelModel objects
+# to the SecondLevelModel object for estimation. We can do this since
+# all subjects share the same design matrix.
+first_level_conditions = [['language', 'language'], ['string', 'string']]
+second_level_input = models
+second_level_model = SecondLevelModel(smoothing_fwhm=8.0)
+second_level_model = second_level_model.fit(second_level_input,
+                                            first_level_conditions)
+
+#########################################################################
+# Computing contrasts at the second level is similar to the first level
+zmap = second_level_model.compute_contrast('language-string')
+
+#########################################################################
+# The group level contrast of the language network is mostly left
+# lateralized as expected
+plotting.plot_glass_brain(zmap, colorbar=False, threshold=norm.isf(0.001),
+                          title='Group language network',
+                          plot_abs=False, display_mode='lr')
+plotting.show()

--- a/examples/plot_hrf.py
+++ b/examples/plot_hrf.py
@@ -43,4 +43,4 @@ for i, hrf_model in enumerate(hrf_models):
     plt.title(hrf_model)
 
 plt.subplots_adjust(bottom=.12)
-fig.show()
+plt.show()

--- a/examples/plot_second_level_button_press.py
+++ b/examples/plot_second_level_button_press.py
@@ -47,7 +47,7 @@ for cidx, tmap in enumerate(data['tmaps']):
                               axes=axes[cidx / 4, cidx % 4],
                               plot_abs=False, display_mode='z')
 fig.suptitle('subjects t_map left-right button press')
-fig.show()
+plt.show()
 
 #########################################################################
 # Estimate second level model

--- a/examples/plot_second_level_button_press.py
+++ b/examples/plot_second_level_button_press.py
@@ -44,7 +44,7 @@ fig, axes = plt.subplots(nrows=4, ncols=4)
 for cidx, tmap in enumerate(data['tmaps']):
     plotting.plot_glass_brain(tmap, colorbar=False, threshold=2.0,
                               title=subjects[cidx],
-                              axes=axes[cidx / 4, cidx % 4],
+                              axes=axes[int(cidx / 4), int(cidx % 4)],
                               plot_abs=False, display_mode='z')
 fig.suptitle('subjects t_map left-right button press')
 plt.show()

--- a/examples/plot_second_level_button_press.py
+++ b/examples/plot_second_level_button_press.py
@@ -14,8 +14,8 @@ More specifically:
 (as fixed effects, then contrast estimation)
 
 Author : Martin Perez-Guevara: 2016
-
 """
+
 import pandas as pd
 from nilearn import plotting
 from scipy.stats import norm
@@ -33,7 +33,7 @@ n_subjects = 16
 data = fetch_localizer_contrasts(["left vs right button press"], n_subjects,
                                  get_tmaps=True)
 
-#########################################################################
+###########################################################################
 # Display subject t_maps
 # ----------------------
 # We plot a grid with all the subjects t-maps thresholded at t = 2 for
@@ -49,7 +49,7 @@ for cidx, tmap in enumerate(data['tmaps']):
 fig.suptitle('subjects t_map left-right button press')
 plt.show()
 
-#########################################################################
+############################################################################
 # Estimate second level model
 # ---------------------------
 # We define the input maps and the design matrix for the second level model
@@ -62,13 +62,13 @@ second_level_model = SecondLevelModel(smoothing_fwhm=8.0)
 second_level_model = second_level_model.fit(second_level_input,
                                             design_matrix=design_matrix)
 
-#########################################################################
+##########################################################################
 # To estimate the contrast is very simple. We can just provide the column
 # name of the design matrix.
 z_map = second_level_model.compute_contrast('left-right',
                                             output_type='z_score')
 
-#########################################################################
+###########################################################################
 # We threshold the second level contrast at uncorrected p < 0.001 and plot
 p_val = 0.001
 z_th = norm.isf(p_val)

--- a/examples/plot_second_level_design_matrix.py
+++ b/examples/plot_second_level_design_matrix.py
@@ -21,18 +21,18 @@ import pandas as pd
 # Create a simple experimental paradigm
 # --------------------------------------
 # Experimental paradigm has two conditions and 20 subjects
-column_names = ['map_name', 'subject_id', 'map_path']
+column_names = ['map_name', 'subject_label', 'map_path']
 n_subjects = 20
 maps_name = ['language'] * n_subjects + ['consonants'] * n_subjects
 subject_list = ['sub-%02d' % i for i in range(1, n_subjects + 1)]
 maps_model = subject_list * 2
 maps_path = [''] * n_subjects * 2
 maps_table = pd.DataFrame({'map_name': maps_name,
-                           'subject_id': maps_model,
+                           'subject_label': maps_model,
                            'effects_map_path': maps_path})
 #########################################################################
 # Specify extra information about the subjects to create confounders
-extra_info_subjects = pd.DataFrame({'subject_id': subject_list,
+extra_info_subjects = pd.DataFrame({'subject_label': subject_list,
                                     'age': range(15, 35),
                                     'sex': [0, 1] * 10})
 

--- a/examples/plot_spm_multimodal_faces.py
+++ b/examples/plot_spm_multimodal_faces.py
@@ -51,7 +51,7 @@ fmri_img[1] = resample_img(fmri_img[1], affine, shape[:3])
 # Create mean image for display
 mean_image = mean_img(fmri_img)
 for idx, img in enumerate(fmri_img):
-    fmri_img[idx] = Nifti1Image(img.get_data(), img.affine)
+    fmri_img[idx] = Nifti1Image(img.get_data(), img.get_affine())
 
 #########################################################################
 # Make design matrices

--- a/nistats/datasets.py
+++ b/nistats/datasets.py
@@ -38,16 +38,14 @@ def fetch_bids_langloc_dataset(data_dir=None, verbose=1):
     downloaded_files: list of string
         Absolute paths of downloaded files on disk
     """
-    data_dir = os.path.join('/media/mfpgt/bigdata/PHD_related/bids_langloc_dataset')
-    # url = 'ftp://ftp.cea.fr/pub/dsv/madic/download/nipy'
-    # dataset_name = "languagelocalizer"
-    # data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
-    #                             verbose=verbose)
-    # # The files_spec needed for _fetch_files
-    # files_spec = [(dataset_name, os.path.join(url, dataset_name),
-    #               {'uncompress': True})]
-    # downloaded_files = _fetch_files(data_dir, files_spec, resume=True,
-    #                                 verbose=verbose)
+    url = 'https://files.osf.io/v1/resources/9q7dv/providers/osfstorage/5888d9a76c613b01fc6acc4e'
+    dataset_name = "bids_langloc_example"
+    data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
+                                verbose=verbose)
+    # The files_spec needed for _fetch_files
+    files_spec = [(dataset_name, url, {'uncompress': False})]
+    downloaded_files = _fetch_files(data_dir, files_spec, resume=True,
+                                    verbose=verbose)
     downloaded_files = []
     return data_dir, downloaded_files
 

--- a/nistats/datasets.py
+++ b/nistats/datasets.py
@@ -56,6 +56,9 @@ def fetch_bids_openfmri_dataset(dataset_name='ds000001', dataset_revision=None,
                                 data_dir=None, verbose=1):
     """Download latest revision of specified bids dataset.
 
+    Compressed files will not be uncompressed automatically due to the expected
+    great size of downloaded dataset.
+
     Parameters
     ----------
     dataset_name: string, optional

--- a/nistats/datasets.py
+++ b/nistats/datasets.py
@@ -44,11 +44,11 @@ def fetch_bids_langloc_dataset(data_dir=None, verbose=1):
     data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
                                 verbose=verbose)
     # The files_spec needed for _fetch_files
-    files_spec = [(main_folder, url, {'uncompress': True,
-                                      'move': main_folder + '.zip'})]
+    files_spec = [('5888d9a76c613b01fc6acc4e', url, {})]
     downloaded_files = _fetch_files(data_dir, files_spec, resume=True,
                                     verbose=verbose)
-    main_path = downloaded_files[0]
+    _uncompress_file(downloaded_files[0])
+    main_path = os.path.join(data_dir, main_folder)
     file_list = [os.path.join(path, f) for
                  path, dirs, files in os.walk(main_path) for f in files]
     return os.path.join(data_dir, main_folder), sorted(file_list)

--- a/nistats/datasets.py
+++ b/nistats/datasets.py
@@ -39,15 +39,18 @@ def fetch_bids_langloc_dataset(data_dir=None, verbose=1):
         Absolute paths of downloaded files on disk
     """
     url = 'https://files.osf.io/v1/resources/9q7dv/providers/osfstorage/5888d9a76c613b01fc6acc4e'
-    dataset_name = "bids_langloc_example"
+    dataset_name = 'bids_langloc_example'
+    main_folder = 'bids_langloc_dataset'
     data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
                                 verbose=verbose)
     # The files_spec needed for _fetch_files
-    files_spec = [(dataset_name, url, {'uncompress': False})]
+    files_spec = [(main_folder, url, {'uncompress': False})]
     downloaded_files = _fetch_files(data_dir, files_spec, resume=True,
                                     verbose=verbose)
-    downloaded_files = []
-    return data_dir, downloaded_files
+    main_path = downloaded_files[0]
+    file_list = [os.path.join(path, f) for
+                 path, dirs, files in os.walk(main_path) for f in files]
+    return os.path.join(data_dir, main_folder), sorted(file_list)
 
 
 def fetch_bids_openfmri_dataset(dataset_name='ds000001', dataset_revision=None,

--- a/nistats/datasets.py
+++ b/nistats/datasets.py
@@ -38,7 +38,7 @@ def fetch_bids_langloc_dataset(data_dir=None, verbose=1):
     downloaded_files: list of string
         Absolute paths of downloaded files on disk
     """
-    data_dir = os.path.join('/media/mfpgt/bigdata/PHD_related/dataset')
+    data_dir = os.path.join('/media/mfpgt/bigdata/PHD_related/bids_langloc_dataset')
     # url = 'ftp://ftp.cea.fr/pub/dsv/madic/download/nipy'
     # dataset_name = "languagelocalizer"
     # data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,

--- a/nistats/datasets.py
+++ b/nistats/datasets.py
@@ -44,7 +44,8 @@ def fetch_bids_langloc_dataset(data_dir=None, verbose=1):
     data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
                                 verbose=verbose)
     # The files_spec needed for _fetch_files
-    files_spec = [(main_folder, url, {'uncompress': False})]
+    files_spec = [(main_folder, url, {'uncompress': True,
+                                      'move': main_folder + '.zip'})]
     downloaded_files = _fetch_files(data_dir, files_spec, resume=True,
                                     verbose=verbose)
     main_path = downloaded_files[0]

--- a/nistats/datasets.py
+++ b/nistats/datasets.py
@@ -91,6 +91,7 @@ def fetch_bids_openfmri_dataset(dataset_name='ds000001', dataset_revision=None,
     files = _fetch_file(openfmri_api, data_dir)
     json_api = json.load(open(files, 'r'))
 
+    dataset_url_set = []
     for i in range(len(json_api)):
         # We look for the desired dataset in the json api file
         if dataset_name == json_api[i]['accession_number']:
@@ -101,7 +102,6 @@ def fetch_bids_openfmri_dataset(dataset_name='ds000001', dataset_revision=None,
                     dataset_revision = revision[-1]['revision_number']
             # After selecting the revision we download all its files
             link_set = json_api[i]['link_set']
-            dataset_url_set = []
             for link in link_set:
                 revision = link['revision']
                 if revision == dataset_revision:

--- a/nistats/datasets.py
+++ b/nistats/datasets.py
@@ -43,12 +43,12 @@ def fetch_bids_langloc_dataset(data_dir=None, verbose=1):
     main_folder = 'bids_langloc_dataset'
     data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
                                 verbose=verbose)
-    zipfile = 'bids_langloc_dataset.zip'
     # The files_spec needed for _fetch_files
-    files_spec = [(zipfile, url, {'move': zipfile})]
-    downloaded_files = _fetch_files(data_dir, files_spec, resume=True,
-                                    verbose=verbose)
-    _uncompress_file(downloaded_files[0])
+    files_spec = [(main_folder + '.zip', url, {'move': main_folder + '.zip'})]
+    if not os.path.exists(os.path.join(data_dir, main_folder)):
+        downloaded_files = _fetch_files(data_dir, files_spec, resume=True,
+                                        verbose=verbose)
+        _uncompress_file(downloaded_files[0])
     main_path = os.path.join(data_dir, main_folder)
     file_list = [os.path.join(path, f) for
                  path, dirs, files in os.walk(main_path) for f in files]

--- a/nistats/datasets.py
+++ b/nistats/datasets.py
@@ -18,47 +18,109 @@ SPM_AUDITORY_DATA_FILES = ["fM00223/fM00223_%03i.img" % index
 SPM_AUDITORY_DATA_FILES.append("sM00223/sM00223_002.img")
 
 
-def fetch_bids_dataset(dataset_name='ds000001', data_dir=None,
-                       verbose=1):
-    """Download bids dataset corresponding to given id"""
+def fetch_bids_langloc_dataset(data_dir=None, verbose=1):
+    """Download language localizer example bids dataset.
+
+    Parameters
+    ----------
+    data_dir: string, optional
+        Path to store the downloaded dataset. if None employ nilearn
+        datasets default download directory.
+
+    verbose: int, optional
+        verbosity level (0 means no message).
+
+    Returns
+    -------
+    data_dir: string
+        Path to downloaded dataset
+
+    downloaded_files: list of string
+        Absolute paths of downloaded files on disk
+    """
+    data_dir = os.path.join('/media/mfpgt/bigdata/PHD_related/dataset')
+    # url = 'ftp://ftp.cea.fr/pub/dsv/madic/download/nipy'
+    # dataset_name = "languagelocalizer"
+    # data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
+    #                             verbose=verbose)
+    # # The files_spec needed for _fetch_files
+    # files_spec = [(dataset_name, os.path.join(url, dataset_name),
+    #               {'uncompress': True})]
+    # downloaded_files = _fetch_files(data_dir, files_spec, resume=True,
+    #                                 verbose=verbose)
+    downloaded_files = []
+    return data_dir, downloaded_files
+
+
+def fetch_bids_openfmri_dataset(dataset_name='ds000001', dataset_revision=None,
+                                data_dir=None, verbose=1):
+    """Download latest revision of specified bids dataset.
+
+    Parameters
+    ----------
+    dataset_name: string, optional
+        Accesion number as published in https://openfmri.org/dataset/.
+        Downloads by default dataset ds000001.
+
+    dataset_revision: string, optional
+        Revision as presented in the specific dataset link accesible
+        from https://openfmri.org/dataset/. Looks for the latest by default.
+
+    data_dir: string, optional
+        Path to store the downloaded dataset. if None employ nilearn
+        datasets default download directory.
+
+    verbose: int, optional
+        verbosity level (0 means no message).
+
+    Returns
+    -------
+    data_dir: string
+        Path to downloaded dataset
+
+    downloaded_files: list of string
+        Absolute paths of downloaded files on disk
+    """
+    # We download a json file with all the api data from the openfmri server
     openfmri_api = 'https://openfmri.org/dataset/api'
     data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
                                 verbose=verbose)
     files = _fetch_file(openfmri_api, data_dir)
     json_api = json.load(open(files, 'r'))
 
-    def _bids_tgz_files(link_set, last_revision):
-        dataset_url_set = []
-        for link in link_set:
-            revision = link['revision']
-            file_type = link['url'][-3:]
-            if last_revision is None and file_type == 'tgz':
-                dataset_url_set.append(link['url'])
-            elif revision == last_revision and file_type == 'tgz':
-                dataset_url_set.append(link['url'])
-        return dataset_url_set
-
     for i in range(len(json_api)):
+        # We look for the desired dataset in the json api file
         if dataset_name == json_api[i]['accession_number']:
-            revision = json_api[i]['revision_set']
-            if revision:
-                last_revision = revision[-1]['revision_number']
-            else:
-                last_revision = None
-            dataset_url_set = _bids_tgz_files(json_api[i]['link_set'],
-                                              last_revision)
+            # Now we look for the desired revision or the last one
+            if not dataset_revision:
+                revision = json_api[i]['revision_set']
+                if revision:
+                    dataset_revision = revision[-1]['revision_number']
+            # After selecting the revision we download all its files
+            link_set = json_api[i]['link_set']
+            dataset_url_set = []
+            for link in link_set:
+                revision = link['revision']
+                if revision == dataset_revision:
+                    dataset_url_set.append(link['url'])
+            # If revision is specified but no file is found there is an issue
+            if dataset_revision and not dataset_url_set:
+                Exception('No files found for revision %s' % dataset_revision)
             break
 
     if not dataset_url_set:
         raise ValueError('dataset %s not found' % dataset_name)
     else:
-        # The options needed for _fetch_files
-        options = [(os.path.basename(dat_url), dat_url,
-                    {'uncompress': True}) for dat_url in dataset_url_set]
-        sub_files = _fetch_files(data_dir, options, resume=True,
-                                 verbose=verbose)
-
-    return sub_files
+        # The files_spec needed for _fetch_files
+        files_spec = []
+        for dat_url in dataset_url_set:
+            target_file = os.path.basename(dat_url)
+            url = dat_url
+            files_spec.append((target_file, url, {}))
+        # download the files
+        downloaded_files = _fetch_files(data_dir, files_spec, resume=True,
+                                        verbose=verbose)
+    return data_dir, downloaded_files
 
 
 def fetch_localizer_first_level(data_dir=None, verbose=1):

--- a/nistats/datasets.py
+++ b/nistats/datasets.py
@@ -43,8 +43,9 @@ def fetch_bids_langloc_dataset(data_dir=None, verbose=1):
     main_folder = 'bids_langloc_dataset'
     data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
                                 verbose=verbose)
+    zipfile = 'bids_langloc_dataset.zip'
     # The files_spec needed for _fetch_files
-    files_spec = [('5888d9a76c613b01fc6acc4e', url, {})]
+    files_spec = [(zipfile, url, {'move': zipfile})]
     downloaded_files = _fetch_files(data_dir, files_spec, resume=True,
                                     verbose=verbose)
     _uncompress_file(downloaded_files[0])

--- a/nistats/datasets.py
+++ b/nistats/datasets.py
@@ -55,12 +55,18 @@ def fetch_bids_langloc_dataset(data_dir=None, verbose=1):
     return os.path.join(data_dir, main_folder), sorted(file_list)
 
 
-def fetch_bids_openfmri_dataset(dataset_name='ds000001', dataset_revision=None,
-                                data_dir=None, verbose=1):
+def fetch_openfmri_dataset(dataset_name='ds000001', dataset_revision=None,
+                           data_dir=None, verbose=1):
     """Download latest revision of specified bids dataset.
 
     Compressed files will not be uncompressed automatically due to the expected
     great size of downloaded dataset.
+
+    Only datasets that contain preprocessed files following the official
+    conventions of the future BIDS derivatives specification can be used out
+    of the box with Nistats. Otherwise custom preprocessing would need to be
+    performed, optionally following the BIDS derivatives specification for the
+    preprocessing output files.
 
     Parameters
     ----------

--- a/nistats/design_matrix.py
+++ b/nistats/design_matrix.py
@@ -456,11 +456,11 @@ def create_second_level_design(maps_table, confounds=None):
     Parameters
     ----------
     maps_table: pandas DataFrame
-        Contains at least columns 'map_name' and 'subject_id'
+        Contains at least columns 'map_name' and 'subject_label'
     confounds: pandas DataFrame, optional
-        If given, contains at least two columns, 'subject_id' and one confound.
+        If given, contains at least two columns, 'subject_label' and one confound.
         confounds and maps_table do not need to agree on their shape,
-        information between them is matched based on the 'subject_id' column
+        information between them is matched based on the 'subject_label' column
         that both must have.
 
     Returns
@@ -469,11 +469,11 @@ def create_second_level_design(maps_table, confounds=None):
         The second level design matrix
     """
     maps_name = maps_table['map_name'].tolist()
-    subjects_id = maps_table['subject_id'].tolist()
+    subjects_id = maps_table['subject_label'].tolist()
     confounds_name = []
     if confounds is not None:
         confounds_name = confounds.columns.tolist()
-        confounds_name.remove('subject_id')
+        confounds_name.remove('subject_label')
     design_columns = (np.unique(maps_name).tolist() +
                       np.unique(subjects_id).tolist() +
                       confounds_name)
@@ -481,9 +481,9 @@ def create_second_level_design(maps_table, confounds=None):
     for ridx, row in maps_table.iterrows():
         design_matrix.loc[ridx] = [0] * len(design_columns)
         design_matrix.loc[ridx, row['map_name']] = 1
-        design_matrix.loc[ridx, row['subject_id']] = 1
+        design_matrix.loc[ridx, row['subject_label']] = 1
         if confounds is not None:
-            conrow = confounds['subject_id'] == row['subject_id']
+            conrow = confounds['subject_label'] == row['subject_label']
             for conf_name in confounds_name:
                 design_matrix.loc[ridx, conf_name] = confounds[conrow][conf_name].values
 

--- a/nistats/first_level_model.py
+++ b/nistats/first_level_model.py
@@ -636,7 +636,8 @@ def first_level_models_from_bids(
         raise TypeError('img_filters must be a list, instead %s was given' %
                         type(img_filters))
     for img_filter in img_filters:
-        if not isinstance(img_filter[0], str) or not isinstance(img_filter[1], str):
+        if (not isinstance(img_filter[0], str) or
+                not isinstance(img_filter[1], str)):
             raise TypeError('filters in img filters must be (str, str), '
                             'instead %s was given' % type(img_filter))
         if img_filter[0] not in ['acq', 'rec', 'run', 'res', 'variant']:
@@ -661,13 +662,13 @@ def first_level_models_from_bids(
             if img_filter[0] in ['acq', 'rec', 'run']:
                 filters.append(img_filter)
 
-        img_specs = get_bids_files(derivatives_path, file_folder='func',
+        img_specs = get_bids_files(derivatives_path, modality_folder='func',
                                    file_tag='preproc', file_type='json',
                                    filters=filters)
         # If we dont find the parameter information in the derivatives folder
         # we try to search in the raw data folder
         if not img_specs:
-            img_specs = get_bids_files(dataset_path, file_folder='func',
+            img_specs = get_bids_files(dataset_path, modality_folder='func',
                                        file_tag='bold', file_type='json',
                                        filters=filters)
         if not img_specs:
@@ -720,7 +721,7 @@ def first_level_models_from_bids(
 
         # Get preprocessed imgs
         filters = [('task', task_label), ('space', space_label)] + img_filters
-        imgs = get_bids_files(derivatives_path, file_folder='func',
+        imgs = get_bids_files(derivatives_path, modality_folder='func',
                               file_tag='preproc', file_type='nii*',
                               sub_label=sub_label, filters=filters)
         # If there is more than one file for the same (ses, run), likely we
@@ -762,7 +763,7 @@ def first_level_models_from_bids(
         # There might be no need to preprocess events to specify model, still
         # throw a warning
         for possible_path in [derivatives_path, dataset_path]:
-            events = get_bids_files(possible_path, file_folder='func',
+            events = get_bids_files(possible_path, modality_folder='func',
                                     file_tag='events', file_type='tsv',
                                     sub_label=sub_label, filters=filters)
             if events:
@@ -784,7 +785,7 @@ def first_level_models_from_bids(
 
         # Get confounds. If not found it will be assumed there are none.
         # If there are confounds, they are assumed to be present for all runs.
-        confounds = get_bids_files(derivatives_path, file_folder='func',
+        confounds = get_bids_files(derivatives_path, modality_folder='func',
                                    file_tag='confounds', file_type='tsv',
                                    sub_label=sub_label, filters=filters)
         if confounds:

--- a/nistats/first_level_model.py
+++ b/nistats/first_level_model.py
@@ -19,6 +19,7 @@ import glob
 import json
 
 import numpy as np
+import pandas as pd
 from nibabel import Nifti1Image
 
 from sklearn.base import BaseEstimator, TransformerMixin, clone

--- a/nistats/first_level_model.py
+++ b/nistats/first_level_model.py
@@ -14,6 +14,9 @@ Author: Bertrand Thirion, Martin Perez-Guevara, 2016
 from warnings import warn
 import time
 import sys
+import os
+import glob
+import json
 
 import numpy as np
 from nibabel import Nifti1Image
@@ -29,7 +32,7 @@ from patsy import DesignInfo
 from .regression import OLSModel, ARModel, SimpleRegressionResults
 from .design_matrix import make_design_matrix
 from .contrasts import _fixed_effect_contrast
-from .utils import _basestring, _check_run_tables
+from .utils import _basestring, _check_run_tables, get_bids_files
 
 
 def mean_scaling(Y, axis=0):

--- a/nistats/first_level_model.py
+++ b/nistats/first_level_model.py
@@ -35,6 +35,9 @@ from .design_matrix import make_design_matrix
 from .contrasts import _fixed_effect_contrast
 from .utils import _basestring, _check_run_tables, get_bids_files
 
+# ATTENTION THIS IS NOT SUPPOSED TO BE HERE
+from nilearn.masking import apply_mask
+
 
 def mean_scaling(Y, axis=0):
     """Scaling of the data to have percent of baseline change along the
@@ -448,10 +451,9 @@ class FirstLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
             # Mask and prepare data for GLM
             if self.verbose > 1:
                 t_masking = time.time()
-                sys.stderr.write('Starting masker computation')
+                sys.stderr.write('Starting masker computation \r')
 
             # ATTENTION THIS IS NOT SUPPOSED TO BE HERE
-            from nilearn.masking import apply_mask
             # Y = self.masker_.transform(run_img)
             Y = apply_mask(run_img, self.masker_.mask_img_)
 

--- a/nistats/first_level_model.py
+++ b/nistats/first_level_model.py
@@ -573,7 +573,7 @@ def first_level_models_from_bids(
         mask=None, target_affine=None, target_shape=None, smoothing_fwhm=None,
         memory=Memory(None), memory_level=1, standardize=False,
         signal_scaling=0, noise_model='ar1', verbose=0, n_jobs=1,
-        minimize_memory=True, subject_label=None):
+        minimize_memory=True):
     """Create FirstLevelModel objects and fit arguments from a BIDS dataset.
 
     It t_r is not specified this function will attempt to load it from a
@@ -625,9 +625,6 @@ def first_level_models_from_bids(
     if not isinstance(task_id, str):
         raise TypeError('task_id must be a string, instead %s was given' %
                         type(task_id))
-    # gather first level model arguments
-    args, _, _, values = inspect.getargvalues(inspect.currentframe())
-    model_kwargs = dict([(arg, values[arg]) for arg in args[4:]])
 
     # check derivatives folder is present
     derivatives_path = os.path.join(dataset_path, 'derivatives')
@@ -685,10 +682,16 @@ def first_level_models_from_bids(
     models_confounds = []
     for sub_label in sub_labels:
         # Create model
-        model_kwargs['t_r'] = t_r
-        model_kwargs['slice_time_ref'] = slice_time_ref
-        model_kwargs['subject_label'] = sub_label
-        model = FirstLevelModel(**model_kwargs)
+        model = FirstLevelModel(
+            t_r=t_r, slice_time_ref=slice_time_ref, hrf_model=hrf_model,
+            drift_model=drift_model, period_cut=period_cut,
+            drift_order=drift_order, fir_delays=fir_delays,
+            min_onset=min_onset, mask=mask, target_affine=target_affine,
+            target_shape=target_shape, smoothing_fwhm=smoothing_fwhm,
+            memory=memory, memory_level=memory_level, standardize=standardize,
+            signal_scaling=signal_scaling, noise_model=noise_model,
+            verbose=verbose, n_jobs=n_jobs, minimize_memory=minimize_memory,
+            subject_label=sub_label)
         models.append(model)
 
         # Get preprocessed imgs

--- a/nistats/first_level_model.py
+++ b/nistats/first_level_model.py
@@ -656,7 +656,7 @@ def first_level_models_from_bids(dataset_path, task_id, model_id=None,
     sub_ids = sorted(list(set(sub_ids)))
 
     # Build fit_kwargs dictionaries to pass to their respective models fit
-    # Events and regressors files must match number of imgs (runs)
+    # Events and confounds files must match number of imgs (runs)
     models = []
     models_fit_kwargs = []
     for sub_id in sub_ids:
@@ -685,10 +685,10 @@ def first_level_models_from_bids(dataset_path, task_id, model_id=None,
                               sub_id=sub_id, filters=filters)
         model_fit_kwargs['run_imgs'] = imgs
 
-        # Get events and extra regressors
+        # Get events and extra confounds
         filters = [('task', task_id)]
         # If model_id is provided we add it to the search constraints for
-        # events and regressors
+        # events and confounds
         if model_id is not None:
             filters.append(('model', model_id))
         # Get events. If not found in derivatives check for original data.
@@ -718,20 +718,20 @@ def first_level_models_from_bids(dataset_path, task_id, model_id=None,
         if not events:
             raise ValueError('No events.tsv files found')
 
-        # Get regressors. If not found it will be assumed there are none.
-        # If there are regressors, they are assumed to be present for all runs.
-        regressors = get_bids_files(derivatives_path, file_folder='func',
+        # Get confounds. If not found it will be assumed there are none.
+        # If there are confounds, they are assumed to be present for all runs.
+        confounds = get_bids_files(derivatives_path, file_folder='func',
                                     file_tag='confounds', file_type='tsv',
                                     sub_id=sub_id, filters=filters)
-        if regressors:
-            if len(regressors) != len(imgs):
-                raise ValueError('%d regressors.tsv files found for %d bold '
+        if confounds:
+            if len(confounds) != len(imgs):
+                raise ValueError('%d confounds.tsv files found for %d bold '
                                  'files. Same number of confound files as '
                                  'the number of runs is expected' %
                                  (len(events), len(imgs)))
-            regressors = [pd.read_csv(c, sep='\t', index_col=None)
-                          for c in regressors]
-            model_fit_kwargs['regressors'] = regressors
+            confounds = [pd.read_csv(c, sep='\t', index_col=None)
+                          for c in confounds]
+            model_fit_kwargs['confounds'] = confounds
         models_fit_kwargs.append(model_fit_kwargs)
 
     return models, models_fit_kwargs

--- a/nistats/first_level_model.py
+++ b/nistats/first_level_model.py
@@ -598,7 +598,8 @@ def first_level_models_from_bids(
         As they are specified in the file names.
 
     All other parameters correspond to a `FirstLevelModel` object, which
-    contains their documentation.
+    contains their documentation. The subject label of the model will be
+    determined directly from the BIDS dataset.
 
     Returns
     -------

--- a/nistats/first_level_model.py
+++ b/nistats/first_level_model.py
@@ -449,7 +449,12 @@ class FirstLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
             if self.verbose > 1:
                 t_masking = time.time()
                 sys.stderr.write('Starting masker computation')
-            Y = self.masker_.transform(run_img)
+
+            # ATTENTION THIS IS NOT SUPPOSED TO BE HERE
+            from nilearn.masking import apply_mask
+            # Y = self.masker_.transform(run_img)
+            Y = apply_mask(run_img, self.masker_.mask_img_)
+
             if self.verbose > 1:
                 t_masking = time.time() - t_masking
                 sys.stderr.write('Masker took %d seconds          \n' % t_masking)

--- a/nistats/first_level_model.py
+++ b/nistats/first_level_model.py
@@ -788,6 +788,7 @@ def first_level_models_from_bids(
         confounds = get_bids_files(derivatives_path, modality_folder='func',
                                    file_tag='confounds', file_type='tsv',
                                    sub_label=sub_label, filters=filters)
+        print(len(confounds), len(imgs))
         if confounds:
             if len(confounds) != len(imgs):
                 raise ValueError('%d confounds.tsv files found for %d bold '

--- a/nistats/first_level_model.py
+++ b/nistats/first_level_model.py
@@ -664,6 +664,8 @@ def first_level_models_from_bids(
         img_specs = get_bids_files(derivatives_path, file_folder='func',
                                    file_tag='preproc', file_type='json',
                                    filters=filters)
+        # If we dont find the parameter information in the derivatives folder
+        # we try to search in the raw data folder
         if not img_specs:
             img_specs = get_bids_files(dataset_path, file_folder='func',
                                        file_tag='bold', file_type='json',
@@ -769,8 +771,8 @@ def first_level_models_from_bids(
                                      'files. Same number of event files as '
                                      'the number of runs is expected' %
                                      (len(events), len(imgs)))
-                events = [pd.read_csv(e, sep='\t', index_col=None)
-                          for e in events]
+                events = [pd.read_csv(event, sep='\t', index_col=None)
+                          for event in events]
                 if possible_path == dataset_path:
                     warn('events taken from directory containing raw data. '
                          'Is it the case that there was no need to preprocess '

--- a/nistats/second_level_model.py
+++ b/nistats/second_level_model.py
@@ -162,9 +162,10 @@ class SecondLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
                                 'In case confounds are provided, first level '
                                 'objects need to provide the attribute '
                                 'subject_label to match rows appropriately.'
-                                'Model at idx %d do not provide it. To set it,'
-                                ' you can do first_level_model.subject_label ='
-                                ' "01"' % (model_idx))
+                                'Model at idx %d does not provide it. '
+                                'To set it, you can do '
+                                'first_level_model.subject_label = "01"'
+                                '' % (model_idx))
             # Check niimgs case
             elif isinstance(second_level_input[0], (str, Nifti1Image)):
                 if design_matrix is None:

--- a/nistats/second_level_model.py
+++ b/nistats/second_level_model.py
@@ -98,7 +98,7 @@ class SecondLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
                             DataFrame or list of Niimg-like objects.
             If list of `FirstLevelModel` objects, then first_level_conditions
             must be provided. If a pandas DataFrame, then they have to contain
-            subject_id, map_name, effects_map_path. If list of Niimg-like
+            subject_label, map_name, effects_map_path. If list of Niimg-like
             objects then this is taken literally as Y for the model fit
             and design_matrix must be provided.
 
@@ -124,12 +124,12 @@ class SecondLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
             argument is ignored.
 
         confounds: pandas DataFrame, optional
-            Must contain a subject_id column. All other columns are
+            Must contain a subject_label column. All other columns are
             considered as confounds and included in the model. If
             design_matrix is provided then this argument is ignored.
             The resulting second level design matrix uses the same column
             names as in the given DataFrame for confounds. At least two columns
-            are expected, "subject_id" and at least one confound.
+            are expected, "subject_label" and at least one confound.
 
         design_matrix: pandas DataFrame, optional
             Design matrix to fit the GLM. The number of rows
@@ -157,14 +157,14 @@ class SecondLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
                                          ' FirstLevelModel object' %
                                          (model_idx, type(first_level_model)))
                     if confounds is not None:
-                        if first_level_model.subject_id is None:
+                        if first_level_model.subject_label is None:
                             raise ValueError(
                                 'In case confounds are provided, first level '
                                 'objects need to provide the attribute '
-                                'subject_id to match rows appropriately. Model'
-                                ' at idx %d do not provide it. To set it, you '
-                                'can do first_level_model.subject_id = "01"' %
-                                (model_idx))
+                                'subject_label to match rows appropriately.'
+                                'Model at idx %d do not provide it. To set it,'
+                                ' you can do first_level_model.subject_label ='
+                                ' "01"' % (model_idx))
             # Check niimgs case
             elif isinstance(second_level_input[0], (str, Nifti1Image)):
                 if design_matrix is None:
@@ -177,10 +177,10 @@ class SecondLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
                                          (model_idx, type(niimg)))
         # Check pandas dataframe case
         elif isinstance(second_level_input, pd.DataFrame):
-            for col in ['subject_id', 'map_name', 'effects_map_path']:
+            for col in ['subject_label', 'map_name', 'effects_map_path']:
                 if col not in second_level_input.columns:
                     raise ValueError('second_level_input DataFrame must have'
-                                     ' columns subject_id, map_name and'
+                                     ' columns subject_label, map_name and'
                                      ' effects_map_path')
             if first_level_conditions is not None:
                 for name, cond in first_level_conditions:
@@ -214,13 +214,13 @@ class SecondLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
         if confounds is not None:
             if not isinstance(confounds, pd.DataFrame):
                 raise ValueError('confounds must be a pandas DataFrame')
-            if 'subject_id' not in confounds.columns:
+            if 'subject_label' not in confounds.columns:
                 raise ValueError('confounds DataFrame must contain column'
-                                 '"subject_id"')
+                                 '"subject_label"')
             if len(confounds.columns) < 2:
                 raise ValueError('confounds should contain at least 2 columns'
-                                 'one called "subject_id" and the other with'
-                                 'a given confound')
+                                 'one called "subject_label" and the other'
+                                 'with a given confound')
 
         # check design matrix
         if design_matrix is not None:
@@ -254,12 +254,12 @@ class SecondLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
                     raise ValueError(
                         'Model at idx %d has not been fit' % model_idx)
             # Get the first level model maps
-            maps_table = pd.DataFrame(columns=['map_name', 'subject_id'])
+            maps_table = pd.DataFrame(columns=['map_name', 'subject_label'])
             effects_maps = []
             for model in second_level_input:
                 for con_name, con_def in first_level_conditions:
                     maps_table.loc[len(maps_table)] = [con_name,
-                                                       model.subject_id]
+                                                       model.subject_label]
                     eff_map = model.compute_contrast(con_def,
                                                      output_type='effect_size')
                     effects_maps.append(eff_map)

--- a/nistats/tests/test_datasets.py
+++ b/nistats/tests/test_datasets.py
@@ -24,6 +24,21 @@ def setup_mock():
 def teardown_mock():
     return tst.teardown_mock(utils, func)
 
+
+@with_setup(setup_mock, teardown_mock)
+def test_fetch_bids_langloc_dataset():
+    datadir, dl_files = datasets.fetch_bids_langloc_dataset()
+    assert_true(isinstance(datadir, _basestring))
+    assert_true(isinstance(dl_files, list))
+
+
+@with_setup(setup_mock, teardown_mock)
+def test_fetch_bids_openfmri_dataset():
+    datadir, dl_files = datasets.fetch_bids_openfmri_dataset()
+    assert_true(isinstance(datadir, _basestring))
+    assert_true(isinstance(dl_files, list))
+
+
 @with_setup(setup_mock, teardown_mock)
 def test_fetch_localizer():
     dataset = datasets.fetch_localizer_first_level()

--- a/nistats/tests/test_datasets.py
+++ b/nistats/tests/test_datasets.py
@@ -27,7 +27,11 @@ def teardown_mock():
 
 
 @with_setup(setup_mock, teardown_mock)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_bids_langloc_dataset():
+    data_dir = os.path.join(tst.tmpdir, 'bids_langloc_example')
+    os.mkdir(data_dir)
+    open(os.path.join(data_dir, 'bids_langloc_dataset.zip'), 'w').close()
     datadir, dl_files = datasets.fetch_bids_langloc_dataset()
     assert_true(isinstance(datadir, _basestring))
     assert_true(isinstance(dl_files, list))

--- a/nistats/tests/test_datasets.py
+++ b/nistats/tests/test_datasets.py
@@ -32,16 +32,11 @@ def teardown_mock():
 def test_fetch_bids_langloc_dataset():
     data_dir = os.path.join(tst.tmpdir, 'bids_langloc_example')
     os.mkdir(data_dir)
-    # main_folder = os.path.join(data_dir, 'bids_langloc_dataset')
-    # os.mkdir(main_folder)
-    testfile = os.path.join(data_dir, 'test.txt')
-    open(testfile, 'w').close()
-    zipname = os.path.join(data_dir, '5888d9a76c613b01fc6acc4e')
-    myzip = zipfile.ZipFile(zipname, 'w')
-    myzip.write(testfile, "bids_langloc_dataset\\test.txt")
-    myzip.close()
-    # open(os.path.join(data_dir, '5888d9a76c613b01fc6acc4e'), 'w').close()
-    datadir, dl_files = datasets.fetch_bids_langloc_dataset()
+    main_folder = os.path.join(data_dir, 'bids_langloc_dataset')
+    os.mkdir(main_folder)
+
+    datadir, dl_files = datasets.fetch_bids_langloc_dataset(tst.tmpdir)
+
     assert_true(isinstance(datadir, _basestring))
     assert_true(isinstance(dl_files, list))
 

--- a/nistats/tests/test_datasets.py
+++ b/nistats/tests/test_datasets.py
@@ -43,13 +43,13 @@ def test_fetch_bids_langloc_dataset():
 
 @with_setup(setup_mock, teardown_mock)
 @with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
-def test_fetch_bids_openfmri_dataset():
+def test_fetch_openfmri_dataset():
     # test dataset not found
     data_dir = os.path.join(tst.tmpdir, 'ds000001')
     os.mkdir(data_dir)
     api_content = [dict(accession_number='dsother')]
     json.dump(api_content, open(os.path.join(data_dir, 'api'), 'w'))
-    assert_raises(ValueError, datasets.fetch_bids_openfmri_dataset,
+    assert_raises(ValueError, datasets.fetch_openfmri_dataset,
                   data_dir=tst.tmpdir)
     # test dataset found with no revision
     data_dir = os.path.join(tst.tmpdir, 'dsother')
@@ -57,7 +57,7 @@ def test_fetch_bids_openfmri_dataset():
     api_content = [dict(accession_number='dsother', revision_set=[],
                         link_set=[dict(revision=None, url='http')])]
     json.dump(api_content, open(os.path.join(data_dir, 'api'), 'w'))
-    data_dir, dl_files = datasets.fetch_bids_openfmri_dataset(
+    data_dir, dl_files = datasets.fetch_openfmri_dataset(
         dataset_name='dsother', data_dir=tst.tmpdir)
     assert_true(isinstance(data_dir, _basestring))
     assert_true(isinstance(dl_files, list))

--- a/nistats/tests/test_datasets.py
+++ b/nistats/tests/test_datasets.py
@@ -31,7 +31,7 @@ def teardown_mock():
 def test_fetch_bids_langloc_dataset():
     data_dir = os.path.join(tst.tmpdir, 'bids_langloc_example')
     os.mkdir(data_dir)
-    open(os.path.join(data_dir, 'bids_langloc_dataset.zip'), 'w').close()
+    os.mkdir(os.path.join(data_dir, 'bids_langloc_dataset'))
     datadir, dl_files = datasets.fetch_bids_langloc_dataset()
     assert_true(isinstance(datadir, _basestring))
     assert_true(isinstance(dl_files, list))

--- a/nistats/tests/test_datasets.py
+++ b/nistats/tests/test_datasets.py
@@ -1,5 +1,6 @@
 import os
 import json
+import zipfile
 import numpy as np
 from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 
@@ -31,7 +32,15 @@ def teardown_mock():
 def test_fetch_bids_langloc_dataset():
     data_dir = os.path.join(tst.tmpdir, 'bids_langloc_example')
     os.mkdir(data_dir)
-    os.mkdir(os.path.join(data_dir, 'bids_langloc_dataset'))
+    # main_folder = os.path.join(data_dir, 'bids_langloc_dataset')
+    # os.mkdir(main_folder)
+    testfile = os.path.join(data_dir, 'test.txt')
+    open(testfile, 'w').close()
+    zipname = os.path.join(data_dir, '5888d9a76c613b01fc6acc4e')
+    myzip = zipfile.ZipFile(zipname, 'w')
+    myzip.write(testfile, "bids_langloc_dataset\\test.txt")
+    myzip.close()
+    # open(os.path.join(data_dir, '5888d9a76c613b01fc6acc4e'), 'w').close()
     datadir, dl_files = datasets.fetch_bids_langloc_dataset()
     assert_true(isinstance(datadir, _basestring))
     assert_true(isinstance(dl_files, list))

--- a/nistats/tests/test_datasets.py
+++ b/nistats/tests/test_datasets.py
@@ -1,4 +1,5 @@
 import os
+import json
 import numpy as np
 from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 
@@ -33,9 +34,24 @@ def test_fetch_bids_langloc_dataset():
 
 
 @with_setup(setup_mock, teardown_mock)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_bids_openfmri_dataset():
-    datadir, dl_files = datasets.fetch_bids_openfmri_dataset()
-    assert_true(isinstance(datadir, _basestring))
+    # test dataset not found
+    data_dir = os.path.join(tst.tmpdir, 'ds000001')
+    os.mkdir(data_dir)
+    api_content = [dict(accession_number='dsother')]
+    json.dump(api_content, open(os.path.join(data_dir, 'api'), 'w'))
+    assert_raises(ValueError, datasets.fetch_bids_openfmri_dataset,
+                  data_dir=tst.tmpdir)
+    # test dataset found with no revision
+    data_dir = os.path.join(tst.tmpdir, 'dsother')
+    os.mkdir(data_dir)
+    api_content = [dict(accession_number='dsother', revision_set=[],
+                        link_set=[dict(revision=None, url='http')])]
+    json.dump(api_content, open(os.path.join(data_dir, 'api'), 'w'))
+    data_dir, dl_files = datasets.fetch_bids_openfmri_dataset(
+        dataset_name='dsother', data_dir=tst.tmpdir)
+    assert_true(isinstance(data_dir, _basestring))
     assert_true(isinstance(dl_files, list))
 
 

--- a/nistats/tests/test_dmtx.py
+++ b/nistats/tests/test_dmtx.py
@@ -495,12 +495,12 @@ def test_spm_2():
 
 
 def _first_level_dataframe():
-    conditions = ['map_name', 'subject_id', 'map_path']
+    conditions = ['map_name', 'subject_label', 'map_path']
     names = ['con_01', 'con_02', 'con_01', 'con_02']
     subjects = ['01', '01', '02', '02']
     maps = ['', '', '', '']
     dataframe = pd.DataFrame({'map_name': names,
-                              'subject_id': subjects,
+                              'subject_label': subjects,
                               'effects_map_path': maps})
     return dataframe
 
@@ -508,7 +508,7 @@ def _first_level_dataframe():
 def test_create_second_level_design():
     first_level_input = _first_level_dataframe()
     regressors = [['01', 0.1], ['02', 0.75]]
-    regressors = pd.DataFrame(regressors, columns=['subject_id', 'f1'])
+    regressors = pd.DataFrame(regressors, columns=['subject_label', 'f1'])
     design = create_second_level_design(first_level_input, regressors)
     expected_design = np.array([[1, 0, 1, 0, 0.1], [0, 1, 1, 0, 0.1],
                                 [1, 0, 0, 1, 0.75], [0, 1, 0, 1, 0.75]])

--- a/nistats/tests/test_first_level_model.py
+++ b/nistats/tests/test_first_level_model.py
@@ -327,11 +327,11 @@ def test_first_level_models_from_bids():
                                              tasks=['localizer', 'main'],
                                              n_runs=[1, 3])
         # test arguments are provided correctly
-        assert_raises(TypeError, first_level_models_from_bids, 2, 'main')
-        assert_raises(ValueError, first_level_models_from_bids, 'lolo', 'main')
-        assert_raises(TypeError, first_level_models_from_bids, bids_path, 2)
+        assert_raises(TypeError, first_level_models_from_bids, 2, 'main', 'MNI')
+        assert_raises(ValueError, first_level_models_from_bids, 'lolo', 'main', 'MNI')
+        assert_raises(TypeError, first_level_models_from_bids, bids_path, 2, 'MNI')
         assert_raises(TypeError, first_level_models_from_bids,
-                      bids_path, 'main', model_init=[])
+                      bids_path, 'main', 'MNI', model_init=[])
         # test output is as expected
         models, m_imgs, m_events, m_confounds = first_level_models_from_bids(
             bids_path, 'main', 'MNI', [('variant', 'some')])
@@ -342,21 +342,21 @@ def test_first_level_models_from_bids():
         # file per img. An one per image or None. Case when one is missing
         confound_files = get_bids_files(os.path.join(bids_path, 'derivatives'),
                                         file_tag='confounds')
-        os.remove(confound_files[0])
+        os.remove(confound_files[-1])
         assert_raises(ValueError, first_level_models_from_bids,
-                      bids_path, 'main')
+                      bids_path, 'main', 'MNI')
 
         # test issues with event files
         events_files = get_bids_files(bids_path, file_tag='events')
         os.remove(events_files[0])
         # one file missing
         assert_raises(ValueError, first_level_models_from_bids,
-                      bids_path, 'main')
+                      bids_path, 'main', 'MNI')
         for f in events_files[1:]:
             os.remove(f)
         # all files missing
         assert_raises(ValueError, first_level_models_from_bids,
-                      bids_path, 'main')
+                      bids_path, 'main', 'MNI')
 
         # check runs are not repeated in obtained files
         # In case different variant and spaces exist and are not selected we
@@ -364,4 +364,4 @@ def test_first_level_models_from_bids():
         shutil.rmtree(os.path.join(bids_path, 'derivatives'))
         # issue if no derivatives folder is present
         assert_raises(ValueError, first_level_models_from_bids,
-                      bids_path, 'main')
+                      bids_path, 'main', 'MNI')

--- a/nistats/tests/test_first_level_model.py
+++ b/nistats/tests/test_first_level_model.py
@@ -334,7 +334,7 @@ def test_first_level_models_from_bids():
                       bids_path, 'main', model_init=[])
         # test output is as expected
         models, m_imgs, m_events, m_confounds = first_level_models_from_bids(
-            bids_path, 'main', preproc_variant='some', preproc_space='MNI')
+            bids_path, 'main', 'MNI', [('variant', 'some')])
         assert_true(len(models) == len(m_imgs))
         assert_true(len(models) == len(m_events))
         assert_true(len(models) == len(m_confounds))

--- a/nistats/tests/test_first_level_model.py
+++ b/nistats/tests/test_first_level_model.py
@@ -333,14 +333,11 @@ def test_first_level_models_from_bids():
         assert_raises(TypeError, first_level_models_from_bids,
                       bids_path, 'main', model_init=[])
         # test output is as expected
-        models, fit_kwargs = first_level_models_from_bids(
+        models, m_imgs, m_events, m_confounds = first_level_models_from_bids(
             bids_path, 'main', preproc_variant='some', preproc_space='MNI')
-        assert_true(len(models) == len(fit_kwargs))
-        assert_true(len(fit_kwargs[0]['events']) ==
-                    len(fit_kwargs[0]['run_imgs']))
-        assert_true(len(fit_kwargs[0]['confounds']) ==
-                    len(fit_kwargs[0]['run_imgs']))
-
+        assert_true(len(models) == len(m_imgs))
+        assert_true(len(models) == len(m_events))
+        assert_true(len(models) == len(m_confounds))
         # test issues with confound files. There should be only one confound
         # file per img. An one per image or None. Case when one is missing
         confound_files = get_bids_files(os.path.join(bids_path, 'derivatives'),

--- a/nistats/tests/test_second_level_model.py
+++ b/nistats/tests/test_second_level_model.py
@@ -80,14 +80,14 @@ def test_fmri_inputs():
         des.to_csv(des_fname)
 
         # prepare correct input first level models
-        flm = FirstLevelModel(subject_id='1').fit(FUNCFILE, design_matrices=des)
+        flm = FirstLevelModel(subject_label='1').fit(FUNCFILE, design_matrices=des)
         flms = [flm, flm, flm]
         # prepare correct input dataframe and lists
         shapes = ((7, 8, 9, 1),)
         _, FUNCFILE, _ = write_fake_fmri_data(shapes)
         FUNCFILE = FUNCFILE[0]
 
-        dfcols = ['subject_id', 'map_name', 'effects_map_path']
+        dfcols = ['subject_label', 'map_name', 'effects_map_path']
         dfrows = [['1', 'a', FUNCFILE], ['2', 'a', FUNCFILE],
                   ['3', 'a', FUNCFILE]]
         niidf = pd.DataFrame(dfrows, columns=dfcols)
@@ -95,7 +95,7 @@ def test_fmri_inputs():
         flcondstr = [('a', 'a')]
         flcondval = [('a', np.array([1]))]
         confounds = pd.DataFrame([['1', 1], ['2', 2], ['3', 3]],
-                                 columns=['subject_id', 'conf1'])
+                                 columns=['subject_label', 'conf1'])
         sdes = pd.DataFrame(X[:3, :3], columns=['a', 'b', 'c'])
 
         # smoke tests with correct input
@@ -123,7 +123,7 @@ def test_fmri_inputs():
         assert_raises(ValueError, SecondLevelModel().fit, flms + [''],
                       flcondval)
         # test dataframe requirements
-        assert_raises(ValueError, SecondLevelModel().fit, niidf['subject_id'])
+        assert_raises(ValueError, SecondLevelModel().fit, niidf['subject_label'])
         # test niimgs requirements
         assert_raises(ValueError, SecondLevelModel().fit, niimgs)
         assert_raises(ValueError, SecondLevelModel().fit, niimgs + [[]], sdes)
@@ -137,12 +137,12 @@ def test_fmri_inputs():
 
 
 def _first_level_dataframe():
-    conditions = ['map_name', 'subject_id', 'map_path']
+    conditions = ['map_name', 'subject_label', 'map_path']
     names = ['con_01', 'con_02', 'con_01', 'con_02']
     subjects = ['01', '01', '02', '02']
     maps = ['', '', '', '']
     dataframe = pd.DataFrame({'map_name': names,
-                              'subject_id': subjects,
+                              'subject_label': subjects,
                               'effects_map_path': maps})
     return dataframe
 
@@ -155,7 +155,7 @@ def test_create_second_level_design():
         first_level_input = _first_level_dataframe()
         first_level_input['effects_map_path'] = [FUNCFILE] * 4
         confounds = [['01', 0.1], ['02', 0.75]]
-        confounds = pd.DataFrame(confounds, columns=['subject_id', 'f1'])
+        confounds = pd.DataFrame(confounds, columns=['subject_label', 'f1'])
         design = create_second_level_design(first_level_input, confounds)
         expected_design = np.array([[1, 0, 1, 0, 0.1], [0, 1, 1, 0, 0.1],
                                     [1, 0, 0, 1, 0.75], [0, 1, 0, 1, 0.75]])

--- a/nistats/tests/test_utils.py
+++ b/nistats/tests/test_utils.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python
-
+import os
+import json
 import numpy as np
 import pandas as pd
 from scipy.stats import norm
 import scipy.linalg as spl
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
 from nose.tools import assert_true, assert_equal, assert_raises
+from nibabel import load, Nifti1Image, save
+from nibabel.tmpdirs import InTemporaryDirectory
 
 from nistats.utils import (multiple_mahalanobis, z_score, multiple_fast_inv,
                            pos_recipr, full_rank, _check_run_tables,
-                           _check_and_load_tables, _check_list_length_match)
+                           _check_and_load_tables, _check_list_length_match,
+                           get_bids_files, parse_bids_filename)
+from nilearn.datasets.tests import test_utils as tst
 
 
 def test_full_rank():
@@ -100,3 +105,130 @@ def test_img_table_checks():
                   [np.array([0]), pd.DataFrame()], "")
     assert_raises(ValueError, _check_run_tables, [''] * 2,
                   ['.csv', pd.DataFrame()], "")
+
+
+def write_fake_bold_img(file_path, shape, rk=3, affine=np.eye(4)):
+    data = np.random.randn(*shape)
+    data[1:-1, 1:-1, 1:-1] += 100
+    save(Nifti1Image(data, affine), file_path)
+    return file_path
+
+
+def basic_paradigm():
+    conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c1', 'c2', 'c2', 'c2']
+    onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
+    paradigm = pd.DataFrame({'trial_type': conditions,
+                             'onset': onsets})
+    return paradigm
+
+
+def basic_confounds(length):
+    columns = ['RotX', 'RotY', 'RotZ', 'X', 'Y', 'Z']
+    data = np.random.rand(length, 6)
+    confounds = pd.DataFrame(data, columns=columns)
+    return confounds
+
+
+def create_fake_bids_dataset(base_dir='', n_sub=10, n_ses=2,
+                             tasks=['localizer', 'main'],
+                             n_runs=[1, 3], with_derivatives=True,
+                             with_confounds=True):
+    bids_path = os.path.join(base_dir, 'bids_dataset')
+    os.makedirs(bids_path)
+    # Create surface bids dataset
+    open(os.path.join(bids_path, 'README.txt'), 'w')
+    vox = 4
+    for subject in ['sub-%02d' % label for label in range(1, n_sub + 1)]:
+        for session in ['ses-%02d' % label for label in range(1, n_ses + 1)]:
+            subses_dir = os.path.join(bids_path, subject, session)
+            if session == 'ses-01':
+                anat_path = os.path.join(subses_dir, 'anat')
+                os.makedirs(anat_path)
+                anat_file = os.path.join(anat_path, subject + '_T1w.nii')
+                open(anat_file, 'w')
+            func_path = os.path.join(subses_dir, 'func')
+            os.makedirs(func_path)
+            for task, n_run in zip(tasks, n_runs):
+                for run in ['run-%02d' % label for label in range(1, n_run + 1)]:
+                    file_id = (subject + '_' + session + '_task-' + task +
+                               '_' + run)
+                    bold_path = os.path.join(func_path, file_id + '_bold.nii')
+                    write_fake_bold_img(bold_path, [vox, vox, vox, 100])
+                    events_path = os.path.join(func_path, file_id +
+                                               '_events.tsv')
+                    basic_paradigm().to_csv(events_path, sep='\t', index=None)
+                    param_path = os.path.join(func_path, file_id +
+                                              '_bold.json')
+                    with open(param_path, 'w') as param_file:
+                        json.dump({'RepetitionTime': 1.5}, param_file)
+
+    # Create derivatives files
+    if with_derivatives:
+        bids_path = os.path.join(base_dir, 'bids_dataset', 'derivatives')
+        os.makedirs(bids_path)
+        for subject in ['sub-%02d' % label for label in range(1, 11)]:
+            for session in ['ses-%02d' % label for label in range(1, 3)]:
+                subses_dir = os.path.join(bids_path, subject, session)
+                func_path = os.path.join(subses_dir, 'func')
+                os.makedirs(func_path)
+                for task, n_run in zip(tasks, n_runs):
+                    for run in ['run-%02d' % label for label in range(1, n_run + 1)]:
+                        file_id = (subject + '_' + session + '_task-' + task +
+                                   '_' + run)
+                        preproc = file_id + '_bold_space-MNI_variant-some_preproc.nii'
+                        preproc_path = os.path.join(func_path, preproc)
+                        write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
+                        preproc = file_id + '_bold_space-T1w_variant-some_preproc.nii'
+                        preproc_path = os.path.join(func_path, preproc)
+                        write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
+                        preproc = file_id + '_bold_space-T1w_variant-other_preproc.nii'
+                        preproc_path = os.path.join(func_path, preproc)
+                        write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
+                        if with_confounds:
+                            confounds_path = os.path.join(func_path, file_id +
+                                                          '_confounds.tsv')
+                            basic_confounds(100).to_csv(confounds_path,
+                                                        sep='\t', index=None)
+    return 'bids_dataset'
+
+
+def test_get_bids_files():
+    with InTemporaryDirectory():
+        bids_path = create_fake_bids_dataset(n_sub=10, n_ses=2,
+                                             tasks=['localizer', 'main'],
+                                             n_runs=[1, 3])
+        selection = get_bids_files(bids_path)
+        assert_true(len(selection) == 250)
+        selection = get_bids_files(bids_path, file_tag='bold')
+        assert_true(len(selection) == 160)
+        selection = get_bids_files(bids_path, file_type='nii')
+        assert_true(len(selection) == 90)
+        selection = get_bids_files(bids_path, sub_label='01')
+        assert_true(len(selection) == 25)
+        selection = get_bids_files(bids_path, file_folder='anat')
+        assert_true(len(selection) == 10)
+        filters = [('task', 'main'), ('run', '01'), ('ses', '02')]
+        selection = get_bids_files(bids_path, file_tag='bold', filters=filters)
+        assert_true(len(selection) == 20)
+        selection = get_bids_files(bids_path, sub_folder=False)
+        assert_true(len(selection) == 1)
+        selection = get_bids_files(bids_path, file_folder='anat', parse=True)
+        assert_true(len(selection) == 10)
+        assert_true(isinstance(selection[0], dict))
+        selection = get_bids_files(bids_path + '/derivatives')
+        assert_true(len(selection) == 320)
+
+
+def test_parse_bids_filename():
+    fields = ['sub', 'ses', 'task', 'lolo']
+    labels = ['01', '01', 'langloc', 'lala']
+    file_name = 'sub-01_ses-01_task-langloc_lolo-lala_bold.nii'
+    file_path = os.path.join('dataset', 'sub-01', 'ses-01', 'func', file_name)
+    file_dict = parse_bids_filename(file_path)
+    for fidx, field in enumerate(fields):
+        assert_true(file_dict[field] == labels[fidx])
+    assert_true(file_dict['file_type'] == 'nii')
+    assert_true(file_dict['file_tag'] == 'bold')
+    assert_true(file_dict['file_path'] == file_path)
+    assert_true(file_dict['file_basename'] == file_name)
+    assert_true(file_dict['file_fields'] == fields)

--- a/nistats/tests/test_utils.py
+++ b/nistats/tests/test_utils.py
@@ -215,7 +215,7 @@ def test_get_bids_files():
         selection = get_bids_files(bids_path, sub_label='01')
         assert_true(len(selection) == 25)
         # There are only 10 files in anat folders. One T1w per subject.
-        selection = get_bids_files(bids_path, file_folder='anat')
+        selection = get_bids_files(bids_path, modality_folder='anat')
         assert_true(len(selection) == 10)
         # 20 files corresponding to run 1 of session 2 of main task.
         # 10 bold.nii.gz and 10 bold.json files. (10 subjects)

--- a/nistats/utils.py
+++ b/nistats/utils.py
@@ -296,7 +296,13 @@ def parse_bids_filename(img_path):
     reference['file_type'] = typ
     reference['file_fields'] = []
     for part in parts[:-1]:
-        field, value = part.split('-')
+        field = part.split('-')[0]
         reference['file_fields'].append(field)
-        reference[field] = value
+        # In derivatives is not clear if the source file name will
+        # be parsed as a field with no value.
+        if len(part.split('-')) > 1:
+            value = part.split('-')[1]
+            reference[field] = value
+        else:
+            reference[field] = None
     return reference

--- a/nistats/utils.py
+++ b/nistats/utils.py
@@ -8,6 +8,8 @@ import numpy as np
 from scipy.stats import norm
 from warnings import warn
 import pandas as pd
+import os
+import glob
 
 py3 = sys.version_info[0] >= 3
 
@@ -205,7 +207,9 @@ def pos_recipr(X):
 
 _basestring = str if py3 else basestring
 
+
 # UTILITIES FOR THE BIDS STANDARD
+
 
 def get_bids_files(main_path, file_tag='*', file_type='*', sub_id='*',
                    file_folder='*', filters=[], ref=False, sub_folder=True,

--- a/nistats/utils.py
+++ b/nistats/utils.py
@@ -341,10 +341,3 @@ def parse_bids_filename(img_path):
         else:
             reference[field] = None
     return reference
-
-
-# I changed the bids api to return properly lists of relevant arguments instead of a dictionary.
-
-# I also simplified get_bids_files to avoid returning dictionaries, it was a bad decision carried forward after refactoring parse_bids_files as an independent function, I see it can simply be called afterwards if desired. I also got rid of allow_other_fields, it seemed like feature creeping at second inspection.
-
-# I addressed or responded to all other comments. I only have doubts about changing the model_init argument of the first_level_models_from_bids function

--- a/nistats/utils.py
+++ b/nistats/utils.py
@@ -131,7 +131,7 @@ def multiple_mahalanobis(effect, covariance):
     -------
     sqd: array of shape (n_samples,)
          the squared distances (one per sample)
-    """ 
+    """
     # check size
     if effect.ndim == 1:
         effect = effect[:, np.newaxis]
@@ -211,7 +211,7 @@ _basestring = str if py3 else basestring
 
 # UTILITIES FOR THE BIDS STANDARD
 def get_bids_files(main_path, file_tag='*', file_type='*', sub_label='*',
-                   file_folder='*', filters=[], sub_folder=True):
+                   modality_folder='*', filters=[], sub_folder=True):
     """Search for files in a BIDS dataset following given constraints.
 
     This utility function allows to filter files in the BIDS dataset by
@@ -247,7 +247,7 @@ def get_bids_files(main_path, file_tag='*', file_type='*', sub_label='*',
         at the level of directories. the label is what follows the 'sub' field
         in the BIDS convention as 'sub-label'.
 
-    file_folder: str accepted by glob, optional (default: '*')
+    modality_folder: str accepted by glob, optional (default: '*')
         Inside the subject and optional session folders a final level of
         folders is expected in the BIDS convention that groups files according
         to different neuroimaging modalities and any other additions of the
@@ -278,11 +278,11 @@ def get_bids_files(main_path, file_tag='*', file_type='*', sub_label='*',
         files = os.path.join(main_path, 'sub-*', 'ses-*')
         if glob.glob(files):
             files = os.path.join(main_path, 'sub-%s' % sub_label, 'ses-*',
-                                 file_folder, 'sub-%s*_%s.%s' %
+                                 modality_folder, 'sub-%s*_%s.%s' %
                                  (sub_label, file_tag, file_type))
         else:
-            files = os.path.join(main_path, 'sub-%s' % sub_label, file_folder,
-                                 'sub-%s*_%s.%s' %
+            files = os.path.join(main_path, 'sub-%s' % sub_label,
+                                 modality_folder, 'sub-%s*_%s.%s' %
                                  (sub_label, file_tag, file_type))
     else:
         files = os.path.join(main_path, '*%s.%s' % (file_tag, file_type))

--- a/nistats/utils.py
+++ b/nistats/utils.py
@@ -223,6 +223,11 @@ def get_bids_files(main_path, file_tag='*', file_type='*', sub_label='*',
     version of the file name as a dictionary for each file found to do more
     detailed operations on the file list.
 
+    Notice that to search in the derivatives folder, it has to be given as
+    part of the main_path. This is useful since the current convention gives
+    exactly the same inner structure to derivatives than to the main BIDS
+    dataset folder, so we can search it in the same way.
+
     Parameters
     ----------
     main_path: str


### PR DESCRIPTION
This PR introduces the first_level_models_from_bids object that allows to automatically extract relevant files by just providing a bids directory. This goes along what seem to be stable agreements on the bids derivatives document still under discussion. Particular on how to name preprocessed bold files and other simple problems. Moreover a downloader for all openfmri datasets is provided alongside a downloader for a downsampled language localizer dataset in the bids format on top of which an example is built for the documentation. All tests and documentation are complete.

The only thing missing is to host the resampled language localizer dataset in the cea server and to first merge the sphinx PR on which this PR depends. Then it will just be a matter of a quick update for this PR.