### PR TITLE
Second level fit corrections

### DIFF
--- a/examples/plot_bids_analysis.py
+++ b/examples/plot_bids_analysis.py
@@ -102,7 +102,10 @@ second_level_model = SecondLevelModel(smoothing_fwhm=8.0)
 second_level_model = second_level_model.fit(second_level_input)
 
 #########################################################################
-# Computing contrasts at the second level is similar to the first level
+# Computing contrasts at the second level is as simple as at the first level
+# Since we are not providing confounders we are performing an one-sample test
+# at the second level with the images determined by the specified first level
+# contrast.
 zmap = second_level_model.compute_contrast(first_level_contrast='language-string')
 
 #########################################################################

--- a/examples/plot_second_level_button_press.py
+++ b/examples/plot_second_level_button_press.py
@@ -71,7 +71,8 @@ z_map = second_level_model.compute_contrast(output_type='z_score')
 # We threshold the second level contrast at uncorrected p < 0.001 and plot
 p_val = 0.001
 z_th = norm.isf(p_val)
-display = plotting.plot_glass_brain(z_map, threshold=z_th, colorbar=True,
-                                    plot_abs=False, display_mode='z')
+display = plotting.plot_glass_brain(
+    z_map, threshold=z_th, colorbar=True, plot_abs=False, display_mode='z',
+    title='group left-right button press (unc p<0.001')
 
 plotting.show()

--- a/examples/plot_second_level_button_press.py
+++ b/examples/plot_second_level_button_press.py
@@ -56,7 +56,7 @@ plt.show()
 # and fit it.
 second_level_input = data['cmaps']
 design_matrix = pd.DataFrame([1] * len(second_level_input),
-                             columns=['contrast'])
+                             columns=['intercept'])
 
 second_level_model = SecondLevelModel(smoothing_fwhm=8.0)
 second_level_model = second_level_model.fit(second_level_input,

--- a/examples/plot_second_level_design_matrix.py
+++ b/examples/plot_second_level_design_matrix.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     raise RuntimeError("This script needs the matplotlib library")
 
-from nistats.design_matrix import (create_simple_second_level_design,
+from nistats.design_matrix import (create_second_level_design,
                                    plot_design_matrix)
 import pandas as pd
 
@@ -21,29 +21,22 @@ import pandas as pd
 # Create a simple experimental paradigm
 # --------------------------------------
 # We want to get the group result of a contrast for 20 subjects
-column_names = ['map_name', 'subject_label', 'map_path']
 n_subjects = 20
-maps_name = ['contrast'] * n_subjects
-subject_list = ['sub-%02d' % i for i in range(1, n_subjects + 1)]
-maps_model = subject_list
-maps_path = [''] * n_subjects
-maps_table = pd.DataFrame({'map_name': maps_name,
-                           'subject_label': maps_model,
-                           'effects_map_path': maps_path})
+subjects_label = ['sub-%02d' % i for i in range(1, n_subjects + 1)]
+
 ##############################################################################
 # Specify extra information about the subjects to create confounders
-# Withoug confounders the design matrix would be correspond to a simple t-test
-extra_info_subjects = pd.DataFrame({'subject_label': subject_list,
-                                    'age': range(15, 35),
-                                    'sex': [0, 1] * 10})
+# Without confounders the design matrix would correspond to a one sample test
+extra_info_subjects = pd.DataFrame({'subject_label': subjects_label,
+                                    'age': range(15, 15 + n_subjects),
+                                    'sex': [0, 1] * int(n_subjects / 2)})
 
 
 #########################################################################
 # Create a second level design matrix
 # -----------------------------------
 
-design_matrix = create_simple_second_level_design(maps_table,
-                                                  extra_info_subjects)
+design_matrix = create_second_level_design(subjects_label, extra_info_subjects)
 
 # plot the results
 ax = plot_design_matrix(design_matrix)

--- a/nistats/design_matrix.py
+++ b/nistats/design_matrix.py
@@ -450,22 +450,21 @@ def plot_design_matrix(design_matrix, rescale=True, ax=None):
     return ax
 
 
-def create_simple_second_level_design(maps_table, confounds=None,
-                                      main_column_name='contrast'):
-    """Sets up a simple second level design from a maps table.
+def create_second_level_design(subjects_label, confounds=None):
+    """Sets up a second level design.
 
-    Basically its a one column design intended for what would be a simple t
-    test if there are no confounders.
+    Construct a design matrix with an intercept and subject specific confounds.
 
     Parameters
     ----------
-    maps_table: pandas DataFrame
-        Contains at least columns 'map_name' and 'subject_label'
+    subjects_label: list of str
+        Contain subject labels to extract confounders in the right order
+        ,corresponding with the images, to create the design matrix.
     confounds: pandas DataFrame, optional
-        If given, contains at least two columns, 'subject_label' and one confound.
-        confounds and maps_table do not need to agree on their shape,
-        information between them is matched based on the 'subject_label' column
-        that both must have.
+        If given, contains at least two columns, 'subject_label' and one
+        confound. The subjects list determine the rows to extract from
+        confounds thanks to its 'subject_label' column. All subjects must
+        be contained in confounds. There should be only one row per subject.
 
     Returns
     -------
@@ -476,71 +475,31 @@ def create_simple_second_level_design(maps_table, confounds=None,
     if confounds is not None:
         confounds_name = confounds.columns.tolist()
         confounds_name.remove('subject_label')
-    design_columns = ([main_column_name] + confounds_name)
-    design_matrix = pd.DataFrame(columns=design_columns)
-    for ridx, row in maps_table.iterrows():
-        design_matrix.loc[ridx] = [0] * len(design_columns)
-        design_matrix.loc[ridx, main_column_name] = 1
-        if confounds is not None:
-            conrow = confounds['subject_label'] == row['subject_label']
-            for conf_name in confounds_name:
-                design_matrix.loc[ridx, conf_name] = confounds[conrow][conf_name].values
 
+    design_columns = (['intercept'] + confounds_name)
     # check column names are unique
     if len(np.unique(design_columns)) != len(design_columns):
         raise ValueError('Design matrix columns do not have unique names')
 
-    # check design matrix is not singular
-    if np.linalg.cond(design_matrix.as_matrix()) < (1. / sys.float_info.epsilon):
-        warn('Attention: Design matrix is singular. Aberrant estimates '
-             'are expected.')
-
-    return design_matrix
-
-
-def create_second_level_design(maps_table, confounds=None):
-    """Sets up a second level design from a maps table.
-
-    Parameters
-    ----------
-    maps_table: pandas DataFrame
-        Contains at least columns 'map_name' and 'subject_label'
-    confounds: pandas DataFrame, optional
-        If given, contains at least two columns, 'subject_label' and one confound.
-        confounds and maps_table do not need to agree on their shape,
-        information between them is matched based on the 'subject_label' column
-        that both must have.
-
-    Returns
-    -------
-    design_matrix: pandas DataFrame
-        The second level design matrix
-    """
-    maps_name = maps_table['map_name'].tolist()
-    subjects_id = maps_table['subject_label'].tolist()
-    confounds_name = []
-    if confounds is not None:
-        confounds_name = confounds.columns.tolist()
-        confounds_name.remove('subject_label')
-    design_columns = (np.unique(maps_name).tolist() +
-                      np.unique(subjects_id).tolist() +
-                      confounds_name)
     design_matrix = pd.DataFrame(columns=design_columns)
-    for ridx, row in maps_table.iterrows():
+    for ridx, subject_label in subjects_label:
         design_matrix.loc[ridx] = [0] * len(design_columns)
-        design_matrix.loc[ridx, row['map_name']] = 1
-        design_matrix.loc[ridx, row['subject_label']] = 1
+        design_matrix.loc[ridx, 'intercept'] = 1
         if confounds is not None:
-            conrow = confounds['subject_label'] == row['subject_label']
+            conrow = confounds['subject_label'] == subject_label
+            if np.sum(conrow) > 1:
+                raise ValueError('confounds contain more than one row for '
+                                 'subject %s' % subject_label)
+            elif np.sum(conrow) == 0:
+                raise ValueError('confounds do not contain subject %s' %
+                                 subject_label)
             for conf_name in confounds_name:
-                design_matrix.loc[ridx, conf_name] = confounds[conrow][conf_name].values
-
-    # check column names are unique
-    if len(np.unique(design_columns)) != len(design_columns):
-        raise ValueError('Design matrix columns do not have unique names')
+                confounds_value = confounds[conrow][conf_name].values
+                design_matrix.loc[ridx, conf_name] = confounds_value
 
     # check design matrix is not singular
-    if np.linalg.cond(design_matrix.as_matrix()) < (1. / sys.float_info.epsilon):
+    epsilon = sys.float_info.epsilon
+    if np.linalg.cond(design_matrix.as_matrix()) < (1. / epsilon):
         warn('Attention: Design matrix is singular. Aberrant estimates '
              'are expected.')
 

--- a/nistats/design_matrix.py
+++ b/nistats/design_matrix.py
@@ -458,13 +458,13 @@ def create_second_level_design(subjects_label, confounds=None):
     Parameters
     ----------
     subjects_label: list of str
-        Contain subject labels to extract confounders in the right order
-        ,corresponding with the images, to create the design matrix.
+        Contain subject labels to extract confounders in the right order,
+        corresponding with the images, to create the design matrix.
     confounds: pandas DataFrame, optional
         If given, contains at least two columns, 'subject_label' and one
-        confound. The subjects list determine the rows to extract from
+        confound. The subjects list determines the rows to extract from
         confounds thanks to its 'subject_label' column. All subjects must
-        be contained in confounds. There should be only one row per subject.
+        have confounds specified. There should be only one row per subject.
 
     Returns
     -------
@@ -476,7 +476,7 @@ def create_second_level_design(subjects_label, confounds=None):
         confounds_name = confounds.columns.tolist()
         confounds_name.remove('subject_label')
 
-    design_columns = (['intercept'] + confounds_name)
+    design_columns = (confounds_name + ['intercept'])
     # check column names are unique
     if len(np.unique(design_columns)) != len(design_columns):
         raise ValueError('Design matrix columns do not have unique names')
@@ -491,7 +491,7 @@ def create_second_level_design(subjects_label, confounds=None):
                 raise ValueError('confounds contain more than one row for '
                                  'subject %s' % subject_label)
             elif np.sum(conrow) == 0:
-                raise ValueError('confounds do not contain subject %s' %
+                raise ValueError('confounds not specified for subject %s' %
                                  subject_label)
             for conf_name in confounds_name:
                 confounds_value = confounds[conrow][conf_name].values

--- a/nistats/design_matrix.py
+++ b/nistats/design_matrix.py
@@ -482,7 +482,7 @@ def create_second_level_design(subjects_label, confounds=None):
         raise ValueError('Design matrix columns do not have unique names')
 
     design_matrix = pd.DataFrame(columns=design_columns)
-    for ridx, subject_label in subjects_label:
+    for ridx, subject_label in enumerate(subjects_label):
         design_matrix.loc[ridx] = [0] * len(design_columns)
         design_matrix.loc[ridx, 'intercept'] = 1
         if confounds is not None:

--- a/nistats/second_level_model.py
+++ b/nistats/second_level_model.py
@@ -392,7 +392,7 @@ class SecondLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
         # Fit an OLS regression for parametric statistics
         Y = self.masker_.transform(effect_maps)
         if self.memory is not None:
-            arg_ignore = ['n_jobs', 'noise_model']
+            arg_ignore = ['n_jobs']
             mem_glm = self.memory.cache(run_glm, ignore=arg_ignore)
         else:
             mem_glm = run_glm

--- a/nistats/second_level_model.py
+++ b/nistats/second_level_model.py
@@ -203,6 +203,13 @@ class SecondLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
                     raise ValueError('second_level_input DataFrame must have'
                                      ' columns subject_label, map_name and'
                                      ' effects_map_path')
+            # Make sure subject_label contain strings
+            second_level_columns = second_level_input.columns.tolist()
+            labels_index = second_level_columns.index('subject_label')
+            labels_dtype = second_level_input.dtypes[labels_index]
+            if not isinstance(labels_dtype, np.object):
+                raise ValueError('subject_label column must be of dtype '
+                                 'object instead of dtype %s' % labels_dtype)
         else:
             raise ValueError('second_level_input must be a list of'
                              ' `FirstLevelModel` objects, a pandas DataFrame'
@@ -220,6 +227,12 @@ class SecondLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
                 raise ValueError('confounds should contain at least 2 columns'
                                  'one called "subject_label" and the other'
                                  'with a given confound')
+            # Make sure subject_label contain strings
+            labels_index = confounds.columns.tolist().index('subject_label')
+            labels_dtype = confounds.dtypes[labels_index]
+            if not isinstance(labels_dtype, np.object):
+                raise ValueError('subject_label column must be of dtype '
+                                 'object instead of dtype %s' % labels_dtype)
 
         # check design matrix
         if design_matrix is not None:
@@ -231,7 +244,7 @@ class SecondLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
         # sort a pandas dataframe by subject_label to avoid inconsistencies
         # with the design matrix row order when automatically extracting maps
         if isinstance(second_level_input, pd.DataFrame):
-            sorted_input = second_level_input.sort_values('subject_label')
+            sorted_input = second_level_input.sort('subject_label')
             second_level_input = sorted_input
 
         self.second_level_input_ = second_level_input

--- a/nistats/tests/test_dmtx.py
+++ b/nistats/tests/test_dmtx.py
@@ -510,7 +510,7 @@ def test_create_second_level_design():
     regressors = [['01', 0.1], ['02', 0.75]]
     regressors = pd.DataFrame(regressors, columns=['subject_label', 'f1'])
     design = create_second_level_design(subjects_label, regressors)
-    expected_design = np.array([[1, 0.75], [1, 0.1]])
+    expected_design = np.array([[0.75, 1], [0.1, 1]])
     assert_array_equal(design, expected_design)
     assert_true(len(design.columns) == 2)
     assert_true(len(design) == 2)

--- a/nistats/tests/test_dmtx.py
+++ b/nistats/tests/test_dmtx.py
@@ -506,12 +506,11 @@ def _first_level_dataframe():
 
 
 def test_create_second_level_design():
-    first_level_input = _first_level_dataframe()
+    subjects_label = ['02', '01']  # change order to test right output order
     regressors = [['01', 0.1], ['02', 0.75]]
     regressors = pd.DataFrame(regressors, columns=['subject_label', 'f1'])
-    design = create_second_level_design(first_level_input, regressors)
-    expected_design = np.array([[1, 0, 1, 0, 0.1], [0, 1, 1, 0, 0.1],
-                                [1, 0, 0, 1, 0.75], [0, 1, 0, 1, 0.75]])
+    design = create_second_level_design(subjects_label, regressors)
+    expected_design = np.array([[1, 0.75], [1, 0.1]])
     assert_array_equal(design, expected_design)
-    assert_true(len(design.columns) == 2 + 2 + 1)
-    assert_true(len(design) == 2 + 2)
+    assert_true(len(design.columns) == 2)
+    assert_true(len(design) == 2)

--- a/nistats/tests/test_second_level_model.py
+++ b/nistats/tests/test_second_level_model.py
@@ -13,7 +13,6 @@ from nibabel import load, Nifti1Image, save
 
 from nistats.first_level_model import FirstLevelModel, run_glm
 from nistats.second_level_model import SecondLevelModel
-from nistats.design_matrix import (create_second_level_design)
 
 from nose.tools import assert_true, assert_equal, assert_raises
 from numpy.testing import (assert_almost_equal, assert_array_equal)


### PR DESCRIPTION
This is a PR preceding permutation methods, the second level model was failing on some of my datasets due to the way the design matrix was being created and the api was more complicated that it needs to be. 

So now the second level design matrix is simply a list of contrasts and confounders. Like in SPM if you are passing directly the maps you would need to create one second level model per contrast to test. Nonetheless using FirstLevelModels as second_level_input allows to specify the first level contrast directly in the second level compute contrast function to avoid creating multiple second level models. So we keep the same flexibility we had before with a simpler API.

The plan in the following PRs is to connect permutation methods and mixed effects directly as an output_type option in the compute_contrast method.