### PR TITLE
MAINT: improves error message when dependencies are not installed

### DIFF
--- a/nistats/version.py
+++ b/nistats/version.py
@@ -37,23 +37,24 @@ REQUIRED_MODULE_METADATA = (
         'min_version': '0.14',
         'required_at_installation': True,
         'install_info': _NISTATS_INSTALL_MSG}),
-    ('nilearn', {
-        'min_version': '0.2.0',
+    ('sklearn', {
+        'min_version': '0.15.0',
         'required_at_installation': True,
         'install_info': _NISTATS_INSTALL_MSG}),
     ('nibabel', {
         'min_version': '2.0.2',
-        'required_at_installation': False}),
+        'required_at_installation': True,
+        'install_info': _NISTATS_INSTALL_MSG}),
+    ('nilearn', {
+        'min_version': '0.2.0',
+        'required_at_installation': True,
+        'install_info': _NISTATS_INSTALL_MSG}),
     ('pandas', {
         'min_version': '0.13.0',
         'required_at_installation': True,
         'install_info': _NISTATS_INSTALL_MSG}),
     ('patsy', {
         'min_version': '0.2.0',
-        'required_at_installation': True,
-        'install_info': _NISTATS_INSTALL_MSG}),
-    ('sklearn', {
-        'min_version': '0.15.0',
         'required_at_installation': True,
         'install_info': _NISTATS_INSTALL_MSG}),
     )
@@ -77,6 +78,11 @@ def _import_module_with_version_check(
             module_name,
             install_info or 'Please install it properly to use nistats.')
         exc.args += (user_friendly_info,)
+        # Necessary for Python 3 because the repr/str of ImportError
+        # objects was changed in Python 3. As a result, user friendly
+        # information is not displayed correctly.
+        if hasattr(exc, 'msg'):
+            exc.msg += '. ' + user_friendly_info
         raise
 
     # Avoid choking on modules with no __version__ attribute

--- a/nistats/version.py
+++ b/nistats/version.py
@@ -31,15 +31,13 @@ _NISTATS_INSTALL_MSG = 'See %s for installation information.' % (
 REQUIRED_MODULE_METADATA = (
     ('numpy', {
         'min_version': '1.8.2',
-        'required_at_installation': True,
         'install_info': _NISTATS_INSTALL_MSG}),
     ('scipy', {
         'min_version': '0.14',
-        'required_at_installation': True,
         'install_info': _NISTATS_INSTALL_MSG}),
     ('sklearn', {
+        'pypi_name': 'scikit-learn',
         'min_version': '0.15.0',
-        'required_at_installation': True,
         'install_info': _NISTATS_INSTALL_MSG}),
     ('nibabel', {
         'min_version': '2.0.2',
@@ -47,17 +45,14 @@ REQUIRED_MODULE_METADATA = (
         'install_info': _NISTATS_INSTALL_MSG}),
     ('nilearn', {
         'min_version': '0.2.0',
-        'required_at_installation': True,
         'install_info': _NISTATS_INSTALL_MSG}),
     ('pandas', {
         'min_version': '0.13.0',
-        'required_at_installation': True,
         'install_info': _NISTATS_INSTALL_MSG}),
     ('patsy', {
         'min_version': '0.2.0',
-        'required_at_installation': True,
         'install_info': _NISTATS_INSTALL_MSG}),
-    )
+)
 
 OPTIONAL_MATPLOTLIB_MIN_VERSION = '1.3.1'
 OPTIONAL_BOTO3_MIN_VERSION = '1.0.0'
@@ -120,10 +115,7 @@ def _check_module_dependencies(is_nistats_installing=False):
     """
 
     for (module_name, module_metadata) in REQUIRED_MODULE_METADATA:
-        if not (is_nistats_installing and
-                not module_metadata['required_at_installation']):
-            # Skip check only when installing and it's a module that
-            # will be auto-installed.
+        if not is_nistats_installing:
             _import_module_with_version_check(
                 module_name=module_name,
                 minimum_version=module_metadata['min_version'],

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,9 @@ if __name__ == "__main__":
         module_check_fn(is_nistats_installing=True)
 
     install_requires = \
-        ['%s>=%s' % (mod, meta['min_version'])
-            for mod, meta in _VERSION_GLOBALS['REQUIRED_MODULE_METADATA']
-            if not meta['required_at_installation']]
+        ['%s>=%s' % (meta.get('pypi_name', mod), meta['min_version'])
+            for mod, meta in _VERSION_GLOBALS['REQUIRED_MODULE_METADATA']]
+    print(install_requires)
 
     setup(name=DISTNAME,
           maintainer=MAINTAINER,


### PR DESCRIPTION
Fixes #154 

- User friendly information about installing dependencies is not shown with Python 3. This PR improves that.
- Changed the order of the dependencies required at installation. For instance, scikit-learn is down the order which should be above nilearn. Same with nibabel.
- Turned 'required_at_installation' for nibabel as True as it is one of the dependency and should be required before nilearn. 