### PR TITLE
FIX: Remove global MPL state change

### DIFF
--- a/nistats/reporting.py
+++ b/nistats/reporting.py
@@ -13,7 +13,6 @@ import matplotlib
 import matplotlib.pyplot as plt
 from patsy import DesignInfo
 from .design_matrix import check_design_matrix
-matplotlib.rc('xtick', labelsize=20)
 
 
 def compare_niimgs(ref_imgs, src_imgs, masker, plot_hist=True, log=True,


### PR DESCRIPTION
Building the docs locally, I find this doesn't change the appearance of the outputs [here](https://nistats.github.io/auto_examples/04_low_level_functions/plot_design_matrix.html). A random survey of other pages also failed to reveal changes in images.

It's unclear to me if this should be replaced with anything, or was perhaps a hack to correct some other source of global state change during development. Please let me know if you think anything more is required.

Closes #164.