### PR TITLE
ENH: Replace DataFrame.as_matrix() with .values

### DIFF
--- a/nistats/design_matrix.py
+++ b/nistats/design_matrix.py
@@ -478,7 +478,7 @@ def create_second_level_design(subjects_label, confounds=None):
 
     # check design matrix is not singular
     epsilon = sys.float_info.epsilon
-    if np.linalg.cond(design_matrix.as_matrix()) > design_matrix.size:
+    if np.linalg.cond(design_matrix.values) > design_matrix.size:
         warn('Attention: Design matrix is singular. Aberrant estimates '
              'are expected.')
     return design_matrix

--- a/nistats/first_level_model.py
+++ b/nistats/first_level_model.py
@@ -462,7 +462,7 @@ class FirstLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
             if self.verbose > 1:
                 t_glm = time.time()
                 sys.stderr.write('Performing GLM computation\r')
-            labels, results = mem_glm(Y, design.as_matrix(),
+            labels, results = mem_glm(Y, design.values,
                                       noise_model=self.noise_model,
                                       bins=100, n_jobs=self.n_jobs)
             if self.verbose > 1:

--- a/nistats/second_level_model.py
+++ b/nistats/second_level_model.py
@@ -249,7 +249,7 @@ class SecondLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
             columns = second_level_input.columns.tolist()
             column_index = columns.index('subject_label')
             sorted_matrix = sorted(
-                second_level_input.as_matrix(), key=lambda x: x[column_index])
+                second_level_input.values, key=lambda x: x[column_index])
             sorted_input = pd.DataFrame(sorted_matrix, columns=columns)
             second_level_input = sorted_input
 
@@ -402,7 +402,7 @@ class SecondLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
             mem_glm = self.memory.cache(run_glm, ignore=arg_ignore)
         else:
             mem_glm = run_glm
-        labels, results = mem_glm(Y, self.design_matrix_.as_matrix(),
+        labels, results = mem_glm(Y, self.design_matrix_.values,
                                   n_jobs=self.n_jobs, noise_model='ols')
         # We save memory if inspecting model details is not necessary
         if self.minimize_memory:

--- a/nistats/tests/test_first_level_model.py
+++ b/nistats/tests/test_first_level_model.py
@@ -269,7 +269,7 @@ def test_first_level_model_glm_computation():
         results1 = model.results_[0]
         labels2, results2 = run_glm(
             model.masker_.transform(func_img),
-            model.design_matrices_[0].as_matrix(), 'ar1')
+            model.design_matrices_[0].values, 'ar1')
         # ar not giving consistent results in python 3.4
         # assert_almost_equal(labels1, labels2, decimal=2) ####FIX
         # assert_equal(len(results1), len(results2)) ####FIX

--- a/nistats/tests/test_second_level_model.py
+++ b/nistats/tests/test_second_level_model.py
@@ -157,7 +157,7 @@ def test_second_level_model_glm_computation():
         results1 = model.results_
 
         labels2, results2 = run_glm(
-            model.masker_.transform(Y), X.as_matrix(), 'ols')
+            model.masker_.transform(Y), X.values, 'ols')
         assert_almost_equal(labels1, labels2, decimal=1)
         assert_equal(len(results1), len(results2))
 


### PR DESCRIPTION
Since Pandas 0.23.0, the following warning has been raised:

```
[...]/nistats/second_level_model.py:405: FutureWarning: Method .as_matrix will be removed in a future version. Use .values instead.
  labels, results = mem_glm(Y, self.design_matrix_.as_matrix(),
```

These have been equivalent at least since version 0.12.0:

* [pandas.DataFrame.as_matrix()](https://pandas.pydata.org/pandas-docs/version/0.12/generated/pandas.DataFrame.as_matrix.html)
* [pandas.DataFrame.values](https://pandas.pydata.org/pandas-docs/version/0.12/generated/pandas.DataFrame.values.html)