### PR TITLE
Removed the unnecessary "General Examples" section

### DIFF
--- a/examples/README.txt
+++ b/examples/README.txt
@@ -12,8 +12,3 @@ Nistats usage examples
 .. contents:: **Contents**
     :local:
     :depth: 1
-
-General examples
-----------------
-
-General-purpose and introductory examples for nistats.


### PR DESCRIPTION
Fix for #151 
Now getting a disappearing whitespace in its place.
The large whitespace is there if I scroll to the top of the page and disappears when I start scrolling down.
Ideas?