### PR TITLE
[MRG] Renamed functon names to use more consistent, less redundant vocabulary

### DIFF
--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -78,9 +78,9 @@ uses.
    :toctree: generated/
    :template: function.rst
 
-   make_design_matrix
+   make_first_level_design_matrix
    check_design_matrix
-   create_second_level_design
+   make_second_level_design_matrix
 
 .. _experimental_paradigm_ref:
 
@@ -283,9 +283,9 @@ uses.
    :template: function.rst
 
    z_score
-   multiple_fast_inv
+   multiple_fast_inverse
    multiple_mahalanobis
    full_rank
-   pos_recipr
+   positive_reciprocal
    get_bids_files
    parse_bids_filename

--- a/examples/02_first_level_models/plot_adhd_dmn.py
+++ b/examples/02_first_level_models/plot_adhd_dmn.py
@@ -20,7 +20,7 @@ from nilearn import datasets, plotting
 from nilearn.input_data import NiftiSpheresMasker
 
 from nistats.first_level_model import FirstLevelModel
-from nistats.design_matrix import make_design_matrix
+from nistats.design_matrix import make_first_level_design_matrix
 
 #########################################################################
 # Prepare data and analysis parameters
@@ -47,9 +47,9 @@ seed_masker = NiftiSpheresMasker([pcc_coords], radius=10, detrend=True,
                                  memory_level=1, verbose=0)
 seed_time_series = seed_masker.fit_transform(adhd_dataset.func[0])
 frametimes = np.linspace(0, (n_scans - 1) * t_r, n_scans)
-design_matrix = make_design_matrix(frametimes, hrf_model='spm',
-                                   add_regs=seed_time_series,
-                                   add_reg_names=["pcc_seed"])
+design_matrix = make_first_level_design_matrix(frametimes, hrf_model='spm',
+                                               add_regs=seed_time_series,
+                                               add_reg_names=["pcc_seed"])
 dmn_contrast = np.array([1] + [0]*(design_matrix.shape[1]-1))
 contrasts = {'seed_based_glm': dmn_contrast}
 

--- a/examples/02_first_level_models/plot_localizer_surface_analysis.py
+++ b/examples/02_first_level_models/plot_localizer_surface_analysis.py
@@ -85,11 +85,11 @@ frame_times = t_r * (np.arange(n_scans) + .5)
 #
 # We specify an hrf model containing Glover model and its time derivative
 # the drift model is implicitly a cosine basis with period cutoff 128s.
-from nistats.design_matrix import make_design_matrix
-design_matrix = make_design_matrix(frame_times,
-                                   events=events,
-                                   hrf_model='glover + derivative'
-                                   )
+from nistats.design_matrix import make_first_level_design_matrix
+design_matrix = make_first_level_design_matrix(frame_times,
+                                               events=events,
+                                               hrf_model='glover + derivative'
+                                               )
 
 #########################################################################
 # Setup and fit GLM.

--- a/examples/02_first_level_models/plot_spm_multimodal_faces.py
+++ b/examples/02_first_level_models/plot_spm_multimodal_faces.py
@@ -55,7 +55,7 @@ mean_image = mean_img(fmri_img)
 # Make design matrices
 import numpy as np
 import pandas as pd
-from nistats.design_matrix import make_design_matrix
+from nistats.design_matrix import make_first_level_design_matrix
 design_matrices = []
 
 #########################################################################
@@ -67,7 +67,7 @@ for idx, img in enumerate(fmri_img, start=1):
     # Define the sampling times for the design matrix
     frame_times = np.arange(n_scans) * tr
     # Build design matrix with the reviously defined parameters
-    design_matrix = make_design_matrix(
+    design_matrix = make_first_level_design_matrix(
             frame_times,
             events,
             hrf_model=hrf_model,

--- a/examples/04_low_level_functions/plot_design_matrix.py
+++ b/examples/04_low_level_functions/plot_design_matrix.py
@@ -50,8 +50,8 @@ events = pd.DataFrame({'trial_type': conditions, 'onset': onsets,
 #########################################################################
 # We sample the events into a design matrix, also including additional regressors
 hrf_model = 'glover'
-from nistats.design_matrix import make_design_matrix
-X1 = make_design_matrix(
+from nistats.design_matrix import make_first_level_design_matrix
+X1 = make_first_level_design_matrix(
     frame_times, events, drift_model='polynomial', drift_order=3,
     add_regs=motion, add_reg_names=add_reg_names, hrf_model=hrf_model)
 
@@ -64,17 +64,17 @@ events = pd.DataFrame({'trial_type': conditions, 'onset': onsets,
 
 #########################################################################
 # Then we sample the design matrix
-X2 = make_design_matrix(frame_times, events, drift_model='polynomial',
-                        drift_order=3, hrf_model=hrf_model)
+X2 = make_first_level_design_matrix(frame_times, events, drift_model='polynomial',
+                                    drift_order=3, hrf_model=hrf_model)
 
 #########################################################################
 # Finally we compute a FIR model
 events = pd.DataFrame({'trial_type': conditions, 'onset': onsets,
                          'duration': duration})
 hrf_model = 'FIR'
-X3 = make_design_matrix(frame_times, events, hrf_model='fir',
-                        drift_model='polynomial', drift_order=3,
-                        fir_delays=np.arange(1, 6))
+X3 = make_first_level_design_matrix(frame_times, events, hrf_model='fir',
+                                    drift_model='polynomial', drift_order=3,
+                                    fir_delays=np.arange(1, 6))
 
 #########################################################################
 # Here the three designs side by side

--- a/examples/04_low_level_functions/plot_second_level_design_matrix.py
+++ b/examples/04_low_level_functions/plot_second_level_design_matrix.py
@@ -36,8 +36,8 @@ extra_info_subjects = pd.DataFrame({'subject_label': subjects_label,
 #########################################################################
 # Create a second level design matrix
 # -----------------------------------
-from nistats.design_matrix import create_second_level_design
-design_matrix = create_second_level_design(subjects_label, extra_info_subjects)
+from nistats.design_matrix import make_second_level_design_matrix
+design_matrix = make_second_level_design_matrix(subjects_label, extra_info_subjects)
 
 #########################################################################
 # plot the results

--- a/nistats/design_matrix.py
+++ b/nistats/design_matrix.py
@@ -5,7 +5,7 @@ This module implements fMRI Design Matrix creation.
 
 Design matrices are represented by Pandas DataFrames
 Computations of the different parts of the design matrix are confined
-to the make_design_matrix function, that create a DataFrame
+to the make_first_level_design_matrix function, that create a DataFrame
 All the others are ancillary functions.
 
 Design matrices contain three different types of regressors:
@@ -278,7 +278,7 @@ def _full_rank(X, cmax=1e15):
 ######################################################################
 
 
-def make_design_matrix(
+def make_first_level_design_matrix(
     frame_times, events=None, hrf_model='glover',
     drift_model='cosine', period_cut=128, drift_order=1, fir_delays=[0],
         add_regs=None, add_reg_names=None, min_onset=-24, oversampling=50):
@@ -441,7 +441,7 @@ def check_design_matrix(design_matrix):
     return frame_times, matrix, names
 
 
-def create_second_level_design(subjects_label, confounds=None):
+def make_second_level_design_matrix(subjects_label, confounds=None):
     """Sets up a second level design.
 
     Construct a design matrix with an intercept and subject specific confounds.

--- a/nistats/first_level_model.py
+++ b/nistats/first_level_model.py
@@ -31,7 +31,7 @@ from sklearn.externals.joblib import Parallel, delayed
 from patsy import DesignInfo
 
 from .regression import OLSModel, ARModel, SimpleRegressionResults
-from .design_matrix import make_design_matrix
+from .design_matrix import make_first_level_design_matrix
 from .contrasts import _fixed_effect_contrast
 from .utils import (_basestring, _check_run_tables,
                     _verify_events_file_uses_tab_separators,
@@ -434,11 +434,11 @@ class FirstLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
                 start_time = self.slice_time_ref * self.t_r
                 end_time = (n_scans - 1 + self.slice_time_ref) * self.t_r
                 frame_times = np.linspace(start_time, end_time, n_scans)
-                design = make_design_matrix(frame_times, events[run_idx],
-                                            self.hrf_model, self.drift_model,
-                                            self.period_cut, self.drift_order,
-                                            self.fir_delays, confounds_matrix,
-                                            confounds_names, self.min_onset)
+                design = make_first_level_design_matrix(frame_times, events[run_idx],
+                                                        self.hrf_model, self.drift_model,
+                                                        self.period_cut, self.drift_order,
+                                                        self.fir_delays, confounds_matrix,
+                                                        confounds_names, self.min_onset)
             else:
                 design = design_matrices[run_idx]
             self.design_matrices_.append(design)

--- a/nistats/model.py
+++ b/nistats/model.py
@@ -12,7 +12,7 @@ from scipy.stats import t as t_distribution
 
 from nibabel.onetime import setattr_on_read
 
-from .utils import pos_recipr
+from .utils import positive_reciprocal
 
 # Inverse t cumulative distribution
 inv_t_cdf = t_distribution.ppf
@@ -98,7 +98,7 @@ class LikelihoodModelResults(object):
         _cov = self.vcov(column=column)
         if _cov.ndim == 2:
             _cov = np.diag(_cov)
-        _t = _theta * pos_recipr(np.sqrt(_cov))
+        _t = _theta * positive_reciprocal(np.sqrt(_cov))
         return _t
 
     def vcov(self, matrix=None, column=None, dispersion=None, other=None):
@@ -200,7 +200,7 @@ class LikelihoodModelResults(object):
             if 'sd' in store:
                 st_sd = np.squeeze(sd)
         if 't' in store:
-            st_t = np.squeeze(effect * pos_recipr(sd))
+            st_t = np.squeeze(effect * positive_reciprocal(sd))
         return TContrastResults(effect=st_effect, t=st_t, sd=st_sd,
                                 df_den=self.df_resid)
 
@@ -258,8 +258,8 @@ class LikelihoodModelResults(object):
         q = matrix.shape[0]
         if invcov is None:
             invcov = inv(self.vcov(matrix=matrix, dispersion=1.0))
-        F = np.add.reduce(np.dot(invcov, ctheta) * ctheta, 0) *\
-            pos_recipr((q * dispersion))
+        F = np.add.reduce(np.dot(invcov, ctheta) * ctheta, 0) * \
+            positive_reciprocal((q * dispersion))
         F = np.squeeze(F)
         return FContrastResults(
             effect=ctheta, covariance=self.vcov(

--- a/nistats/regression.py
+++ b/nistats/regression.py
@@ -29,7 +29,7 @@ from numpy.linalg import matrix_rank
 
 from nibabel.onetime import setattr_on_read
 
-from .utils import pos_recipr
+from .utils import positive_reciprocal
 
 from .model import LikelihoodModelResults
 
@@ -308,7 +308,7 @@ class RegressionResults(LikelihoodModelResults):
         See: Montgomery and Peck 3.2.1 p. 68
              Davidson and MacKinnon 15.2 p 662
         """
-        return self.resid * pos_recipr(np.sqrt(self.dispersion))
+        return self.resid * positive_reciprocal(np.sqrt(self.dispersion))
 
     @setattr_on_read
     def predicted(self):
@@ -382,7 +382,7 @@ class SimpleRegressionResults(LikelihoodModelResults):
         See: Montgomery and Peck 3.2.1 p. 68
              Davidson and MacKinnon 15.2 p 662
         """
-        return self.resid(Y) * pos_recipr(np.sqrt(self.dispersion))
+        return self.resid(Y) * positive_reciprocal(np.sqrt(self.dispersion))
 
     def predicted(self):
         """ Return linear predictor values from a design matrix.

--- a/nistats/second_level_model.py
+++ b/nistats/second_level_model.py
@@ -27,7 +27,7 @@ from .first_level_model import run_glm
 from .regression import SimpleRegressionResults
 from .contrasts import compute_contrast
 from .utils import _basestring
-from .design_matrix import create_second_level_design
+from .design_matrix import make_second_level_design_matrix
 
 
 def _infer_effect_maps(second_level_input, contrast_def):
@@ -284,8 +284,8 @@ class SecondLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
 
         # Create and set design matrix, if not given
         if design_matrix is None:
-            design_matrix = create_second_level_design(subjects_label,
-                                                       confounds)
+            design_matrix = make_second_level_design_matrix(subjects_label,
+                                                            confounds)
         self.design_matrix_ = design_matrix
 
         # Learn the mask. Assume the first level imgs have been masked.

--- a/nistats/tests/test_first_level_model.py
+++ b/nistats/tests/test_first_level_model.py
@@ -13,7 +13,7 @@ from nibabel import load, Nifti1Image
 
 from nistats.first_level_model import (mean_scaling, run_glm, FirstLevelModel,
                                        first_level_models_from_bids)
-from nistats.design_matrix import check_design_matrix, make_design_matrix
+from nistats.design_matrix import check_design_matrix, make_first_level_design_matrix
 
 from nose.tools import assert_true, assert_equal, assert_raises
 from numpy.testing import (assert_almost_equal, assert_array_equal)
@@ -244,8 +244,8 @@ def test_first_level_model_design_creation():
         start_time = slice_time_ref * t_r
         end_time = (n_scans - 1 + slice_time_ref) * t_r
         frame_times = np.linspace(start_time, end_time, n_scans)
-        design = make_design_matrix(frame_times, events,
-                                    drift_model='polynomial', drift_order=3)
+        design = make_first_level_design_matrix(frame_times, events,
+                                                drift_model='polynomial', drift_order=3)
         frame2, X2, names2 = check_design_matrix(design)
         assert_array_equal(frame1, frame2)
         assert_array_equal(X1, X2)

--- a/nistats/tests/test_reporting.py
+++ b/nistats/tests/test_reporting.py
@@ -5,7 +5,7 @@ from numpy.testing import dec
 from nose.tools import assert_true
 from nibabel.tmpdirs import InTemporaryDirectory
 
-from nistats.design_matrix import make_design_matrix
+from nistats.design_matrix import make_first_level_design_matrix
 from nistats.reporting import (plot_design_matrix, get_clusters_table,
                                _local_max, plot_contrast_matrix)
 
@@ -27,7 +27,7 @@ else:
 def test_show_design_matrix():
     # test that the show code indeed (formally) runs
     frame_times = np.linspace(0, 127 * 1., 128)
-    dmtx = make_design_matrix(
+    dmtx = make_first_level_design_matrix(
         frame_times, drift_model='polynomial', drift_order=3)
     ax = plot_design_matrix(dmtx)
     assert (ax is not None)
@@ -42,7 +42,7 @@ def test_show_design_matrix():
 def test_show_contrast_matrix():
     # test that the show code indeed (formally) runs
     frame_times = np.linspace(0, 127 * 1., 128)
-    dmtx = make_design_matrix(
+    dmtx = make_first_level_design_matrix(
         frame_times, drift_model='polynomial', drift_order=3)
     contrast = np.ones(4)
     ax = plot_contrast_matrix(contrast, dmtx)

--- a/nistats/tests/test_utils.py
+++ b/nistats/tests/test_utils.py
@@ -11,8 +11,8 @@ from nibabel import load, Nifti1Image
 from nibabel.tmpdirs import InTemporaryDirectory
 from nose import with_setup
 
-from nistats.utils import (multiple_mahalanobis, z_score, multiple_fast_inv,
-                           pos_recipr, full_rank, _check_run_tables,
+from nistats.utils import (multiple_mahalanobis, z_score, multiple_fast_inverse,
+                           positive_reciprocal, full_rank, _check_run_tables,
                            _check_and_load_tables, _check_list_length_match,
                            get_bids_files, parse_bids_filename,
                            get_design_from_fslmat)
@@ -69,26 +69,26 @@ def test_multiple_fast_inv():
     for i in range(shape[0]):
         X[i] = np.dot(X[i], X[i].T)
         X_inv_ref[i] = spl.inv(X[i])
-    X_inv = multiple_fast_inv(X)
+    X_inv = multiple_fast_inverse(X)
     assert_almost_equal(X_inv_ref, X_inv)
 
 
 def test_pos_recipr():
     X = np.array([2, 1, -1, 0], dtype=np.int8)
     eX = np.array([0.5, 1, 0, 0])
-    Y = pos_recipr(X)
+    Y = positive_reciprocal(X)
     yield assert_array_almost_equal, Y, eX
     yield assert_equal, Y.dtype.type, np.float64
     X2 = X.reshape((2, 2))
-    Y2 = pos_recipr(X2)
+    Y2 = positive_reciprocal(X2)
     yield assert_array_almost_equal, Y2, eX.reshape((2, 2))
     # check that lists have arrived
     XL = [0, 1, -1]
-    yield assert_array_almost_equal, pos_recipr(XL), [0, 1, 0]
+    yield assert_array_almost_equal, positive_reciprocal(XL), [0, 1, 0]
     # scalars
-    yield assert_equal, pos_recipr(-1), 0
-    yield assert_equal, pos_recipr(0), 0
-    yield assert_equal, pos_recipr(2), 0.5
+    yield assert_equal, positive_reciprocal(-1), 0
+    yield assert_equal, positive_reciprocal(0), 0
+    yield assert_equal, positive_reciprocal(2), 0.5
 
 
 def test_img_table_checks():

--- a/nistats/utils.py
+++ b/nistats/utils.py
@@ -137,7 +137,7 @@ def z_score(pvalue):
     return norm.isf(pvalue)
 
 
-def multiple_fast_inv(a):
+def multiple_fast_inverse(a):
     """Compute the inverse of a set of arrays.
 
     Parameters
@@ -226,7 +226,7 @@ def multiple_mahalanobis(effect, covariance):
     Xt, Kt = np.ascontiguousarray(effect.T), np.ascontiguousarray(covariance.T)
 
     # compute the inverse of the covariances
-    Kt = multiple_fast_inv(Kt)
+    Kt = multiple_fast_inverse(Kt)
 
     # derive the squared Mahalanobis distances
     sqd = np.sum(np.sum(Xt[:, :, np.newaxis] * Xt[:, np.newaxis] * Kt, 1), 1)
@@ -265,7 +265,7 @@ def full_rank(X, cmax=1e15):
     return X, cmax
 
 
-def pos_recipr(X):
+def positive_reciprocal(X):
     """ Return element-wise reciprocal of array, setting `X`>=0 to 0
 
     Return the reciprocal of an array, setting all entries less than or


### PR DESCRIPTION
 - nistats.design_matrix.make_design_matrix -> make_first_level_design_matrix
 - nistats.design_matrix.create_second_level_design -> make_second_level_design_matrix
 - nistats.utils.pos_recipr -> positive_reciprocal.
 - nistats.utils.multiple_fast_inv -> nistats.utils.multiple_fast_inverse
issue #184 