### PR TITLE
Added a DeprecationWarning for Python 3.4

### DIFF
--- a/nistats/__init__.py
+++ b/nistats/__init__.py
@@ -32,7 +32,7 @@ import warnings
 from .version import _check_module_dependencies, __version__
 
 
-def py2_deprecation_warning():
+def _py2_deprecation_warning():
     warnings.simplefilter('once')
     py2_warning = ('Python2 support is deprecated and will be removed in '
                    'a future release. Consider switching to Python3.')
@@ -58,4 +58,4 @@ _check_module_dependencies()
 
 
 __all__ = ['__version__', 'datasets', 'design_matrix']
-py2_deprecation_warning()
+_py2_deprecation_warning()

--- a/nistats/__init__.py
+++ b/nistats/__init__.py
@@ -26,7 +26,7 @@ utils                   --- Miscelaneous utilities
 """
 
 import gzip
-import six
+import sys
 import warnings
 
 from .version import _check_module_dependencies, __version__
@@ -36,10 +36,22 @@ def py2_deprecation_warning():
     warnings.simplefilter('once')
     py2_warning = ('Python2 support is deprecated and will be removed in '
                    'a future release. Consider switching to Python3.')
-    if six.PY2:
+    if sys.version_info.major == 2:
         warnings.warn(message=py2_warning,
                       category=DeprecationWarning,
                       stacklevel=4,
+                      )
+
+
+def _py34_deprecation_warning():
+    warnings.simplefilter('once')
+    py34_warning = ('Python 3.4 support is deprecated and will be removed in '
+                   'a future release. Consider switching to Python 3.6 or 3.7.'
+                   )
+    if sys.version_info.major == 3 and sys.version_info.minor == 4:
+        warnings.warn(message=py34_warning,
+                      category=DeprecationWarning,
+                      stacklevel=3,
                       )
 
 _check_module_dependencies()

--- a/nistats/tests/test_init.py
+++ b/nistats/tests/test_init.py
@@ -1,0 +1,19 @@
+import sys
+import warnings
+
+from nose.tools import assert_true
+from nistats import _py2_deprecation_warning, _py34_deprecation_warning
+
+
+def test_py2_deprecation_warning():
+    if sys.version_info.major == 2:
+        with warnings.catch_warnings(record=True) as raised_warnings:
+            _py2_deprecation_warning()
+            assert_true(raised_warnings[0].category is DeprecationWarning)
+
+
+def test_py34_deprecation_warning():
+    if sys.version_info.major == 3 and sys.version_info.minor == 4:
+        with warnings.catch_warnings(record=True) as raised_warnings:
+            _py34_deprecation_warning()
+            assert_true(raised_warnings[0].category is DeprecationWarning)


### PR DESCRIPTION
Same as issue https://github.com/nilearn/nilearn/issues/1877
Also replaced use of six with sys.version_info for Python version determination (stdlib use over ext lib).