### PR TITLE
[MRG] Address design deficiencies in python deprecation functions & tests

### DIFF
--- a/nistats/__init__.py
+++ b/nistats/__init__.py
@@ -35,23 +35,24 @@ from .version import _check_module_dependencies, __version__
 def _py2_deprecation_warning():
     py2_warning = ('Python2 support is deprecated and will be removed in '
                    'a future release. Consider switching to Python3.')
+    warnings.filterwarnings('once', message=py2_warning)
     warnings.warn(message=py2_warning,
                   category=DeprecationWarning,
                   stacklevel=3,
                   )
 
-
 def _py34_deprecation_warning():
     py34_warning = ('Python 3.4 support is deprecated and will be removed in '
                    'a future release. Consider switching to Python 3.6 or 3.7.'
                    )
+    warnings.filterwarnings('once', message=py34_warning)
     warnings.warn(message=py34_warning,
                   category=DeprecationWarning,
                   stacklevel=3,
                   )
 
+
 def _python_deprecation_warnings():
-    warnings.simplefilter('once')
     if sys.version_info.major == 2:
         _py2_deprecation_warning()
     elif sys.version_info.major == 3 and sys.version_info.minor == 4:

--- a/nistats/__init__.py
+++ b/nistats/__init__.py
@@ -33,29 +33,33 @@ from .version import _check_module_dependencies, __version__
 
 
 def _py2_deprecation_warning():
-    warnings.simplefilter('once')
     py2_warning = ('Python2 support is deprecated and will be removed in '
                    'a future release. Consider switching to Python3.')
-    if sys.version_info.major == 2:
-        warnings.warn(message=py2_warning,
-                      category=DeprecationWarning,
-                      stacklevel=4,
-                      )
+    warnings.warn(message=py2_warning,
+                  category=DeprecationWarning,
+                  stacklevel=3,
+                  )
 
 
 def _py34_deprecation_warning():
-    warnings.simplefilter('once')
     py34_warning = ('Python 3.4 support is deprecated and will be removed in '
                    'a future release. Consider switching to Python 3.6 or 3.7.'
                    )
-    if sys.version_info.major == 3 and sys.version_info.minor == 4:
-        warnings.warn(message=py34_warning,
-                      category=DeprecationWarning,
-                      stacklevel=3,
-                      )
+    warnings.warn(message=py34_warning,
+                  category=DeprecationWarning,
+                  stacklevel=3,
+                  )
+
+def _python_deprecation_warnings():
+    warnings.simplefilter('once')
+    if sys.version_info.major == 2:
+        _py2_deprecation_warning()
+    elif sys.version_info.major == 3 and sys.version_info.minor == 4:
+        _py34_deprecation_warning()
+
 
 _check_module_dependencies()
-
+_python_deprecation_warnings()
 
 __all__ = ['__version__', 'datasets', 'design_matrix']
 _py2_deprecation_warning()

--- a/nistats/tests/test_init.py
+++ b/nistats/tests/test_init.py
@@ -4,22 +4,34 @@ import warnings
 from nose.tools import assert_true
 
 
-def test_py2_deprecation_warning():
+# import time warnings don't interfere with warning's tests
+with warnings.catch_warnings(record=True):
+    from nistats import _py34_deprecation_warning
     from nistats import _py2_deprecation_warning
+    from nistats import _python_deprecation_warnings
+
+
+def test_py2_deprecation_warning():
     with warnings.catch_warnings(record=True) as raised_warnings:
-        _py2_deprecation_warning()
+            _py2_deprecation_warning()
     assert_true(raised_warnings[0].category is DeprecationWarning)
+    assert_true(
+            str(raised_warnings[0].message).startswith(
+                    'Python2 support is deprecated')
+            )
 
 
 def test_py34_deprecation_warning():
-    from nistats import _py34_deprecation_warning
     with warnings.catch_warnings(record=True) as raised_warnings:
         _py34_deprecation_warning()
     assert_true(raised_warnings[0].category is DeprecationWarning)
+    assert_true(
+            str(raised_warnings[0].message).startswith(
+            'Python 3.4 support is deprecated')
+            )
 
 
 def test_python_deprecation_warnings():
-    from nistats import _python_deprecation_warnings
     with warnings.catch_warnings(record=True) as raised_warnings:
         _python_deprecation_warnings()
     if sys.version_info.major == 2:
@@ -36,3 +48,18 @@ def test_python_deprecation_warnings():
                 )
     else:
         assert_true(len(raised_warnings) == 0)
+
+
+def test_warnings_filter_scope():
+    """
+    Tests that warnings generated at Nistats import in Python 2, 3.4 envs
+    do not change the warnings filter for subsequent warnings.
+    """
+    with warnings.catch_warnings(record=True) as raised_warnings:
+        warnings.warn('Dummy warning 1')  # Will be raised.
+        warnings.filterwarnings("ignore", message="Dummy warning")
+        warnings.warn('Dummy warning 2')  # Will not be raised.
+        import nistats  # Irrespective of warning raised in py2, py3.4 ...
+        warnings.warn('Dummy warning 3')  # ...this should not be raised.
+    assert str(raised_warnings[0].message) == 'Dummy warning 1'
+    assert str(raised_warnings[-1].message) != 'Dummy warning 3'

--- a/nistats/tests/test_init.py
+++ b/nistats/tests/test_init.py
@@ -2,18 +2,37 @@ import sys
 import warnings
 
 from nose.tools import assert_true
-from nistats import _py2_deprecation_warning, _py34_deprecation_warning
 
 
 def test_py2_deprecation_warning():
-    if sys.version_info.major == 2:
-        with warnings.catch_warnings(record=True) as raised_warnings:
-            _py2_deprecation_warning()
-            assert_true(raised_warnings[0].category is DeprecationWarning)
+    from nistats import _py2_deprecation_warning
+    with warnings.catch_warnings(record=True) as raised_warnings:
+        _py2_deprecation_warning()
+    assert_true(raised_warnings[0].category is DeprecationWarning)
 
 
 def test_py34_deprecation_warning():
-    if sys.version_info.major == 3 and sys.version_info.minor == 4:
-        with warnings.catch_warnings(record=True) as raised_warnings:
-            _py34_deprecation_warning()
-            assert_true(raised_warnings[0].category is DeprecationWarning)
+    from nistats import _py34_deprecation_warning
+    with warnings.catch_warnings(record=True) as raised_warnings:
+        _py34_deprecation_warning()
+    assert_true(raised_warnings[0].category is DeprecationWarning)
+
+
+def test_python_deprecation_warnings():
+    from nistats import _python_deprecation_warnings
+    with warnings.catch_warnings(record=True) as raised_warnings:
+        _python_deprecation_warnings()
+    if sys.version_info.major == 2:
+        assert_true(raised_warnings[0].category is DeprecationWarning)
+        assert_true(
+                str(raised_warnings[0].message).startswith(
+                        'Python2 support is deprecated')
+                )
+    elif sys.version_info.major == 3 and sys.version_info.minor == 4:
+        assert_true(raised_warnings[0].category is DeprecationWarning)
+        assert_true(
+                str(raised_warnings[0].message).startswith(
+                        'Python 3.4 support is deprecated')
+                )
+    else:
+        assert_true(len(raised_warnings) == 0)


### PR DESCRIPTION
Lays the groundwork for addressing the issue raised in https://github.com/nilearn/nilearn/pull/1882#discussion_r241610908
Also
 - Simplifies testing the 2 deprecation functions.
 - Reduced redundant code.
 - Sets the stage for solving the glitch where importing Nistats in Py2, 3.4
 overrides the warnings filter of subsequent warnings & testing it.