### PR TITLE
[MRG] Refactor utility functions useful in testing

### DIFF
--- a/nistats/_utils/testing.py
+++ b/nistats/_utils/testing.py
@@ -6,7 +6,7 @@ import pandas as pd
 from nibabel import Nifti1Image
 
 
-def write_fake_fmri_data(shapes, rk=3, affine=np.eye(4)):
+def _write_fake_fmri_data(shapes, rk=3, affine=np.eye(4)):
     mask_file, fmri_files, design_files = 'mask.nii', [], []
     for i, shape in enumerate(shapes):
         fmri_files.append('fmri_run%d.nii' % i)
@@ -21,7 +21,7 @@ def write_fake_fmri_data(shapes, rk=3, affine=np.eye(4)):
     return mask_file, fmri_files, design_files
 
 
-def generate_fake_fmri_data(shapes, rk=3, affine=np.eye(4)):
+def _generate_fake_fmri_data(shapes, rk=3, affine=np.eye(4)):
     fmri_data = []
     design_matrices = []
     for i, shape in enumerate(shapes):
@@ -57,18 +57,53 @@ def _basic_confounds(length):
     return confounds
 
 
-def create_fake_bids_dataset(base_dir='', n_sub=10, n_ses=2,
+def _create_fake_bids_dataset(base_dir='', n_sub=10, n_ses=2,
                              tasks=['localizer', 'main'],
                              n_runs=[1, 3], with_derivatives=True,
                              with_confounds=True, no_session=False):
-    """Returns a fake bids dataset directory with dummy files
-
-    In the case derivatives are included, they come with two spaces and
-    variants. Spaces are 'MNI' and 'T1w'. Variants are 'some' and 'other'.
-    Only space 'T1w' include both variants.
-
-    Specifying no_sessions will only produce runs and files without the
-    optional session field. In this case n_ses will be ignored.
+    """Creates a fake bids dataset directory with dummy files.
+    Returns fake dataset directory name.
+    
+    Parameters
+    ----------
+    base_dir: string (Absolute path), optional
+        Absolute directory path in which to create the fake BIDS dataset dir.
+        Default: Current directory.
+        
+    n_sub: int, optional
+        Number of subject to be simulated in the dataset.
+        Default: 10
+        
+    n_ses: int, optional
+        Number of sessions to be simulated in the dataset.
+        Ignored if no_session=True.
+        Default: 2
+        
+    n_runs: List[int], optional
+        Default: [1, 3]
+        
+    with_derivatives: bool, optional
+        In the case derivatives are included, they come with two spaces and
+        variants. Spaces are 'MNI' and 'T1w'. Variants are 'some' and 'other'.
+        Only space 'T1w' include both variants.
+        Default: True
+        
+    with_confounds: bool, optional
+        Default: True
+        
+    no_session: bool, optional
+        Specifying no_sessions will only produce runs and files without the
+        optional session field. In this case n_ses will be ignored.
+        Default: False
+        
+    Returns
+    -------
+    dataset directory name: string
+        'bids_dataset'
+        
+    Creates
+    -------
+        Directory with dummy files
     """
     bids_path = os.path.join(base_dir, 'bids_dataset')
     os.makedirs(bids_path)

--- a/nistats/_utils/testing.py
+++ b/nistats/_utils/testing.py
@@ -1,0 +1,140 @@
+import json
+import os
+
+import numpy as np
+import pandas as pd
+from nibabel import Nifti1Image
+
+
+def write_fake_fmri_data(shapes, rk=3, affine=np.eye(4)):
+    mask_file, fmri_files, design_files = 'mask.nii', [], []
+    for i, shape in enumerate(shapes):
+        fmri_files.append('fmri_run%d.nii' % i)
+        data = np.random.randn(*shape)
+        data[1:-1, 1:-1, 1:-1] += 100
+        Nifti1Image(data, affine).to_filename(fmri_files[-1])
+        design_files.append('dmtx_%d.csv' % i)
+        pd.DataFrame(np.random.randn(shape[3], rk),
+                     columns=['', '', '']).to_csv(design_files[-1])
+    Nifti1Image((np.random.rand(*shape[:3]) > .5).astype(np.int8),
+                affine).to_filename(mask_file)
+    return mask_file, fmri_files, design_files
+
+
+def generate_fake_fmri_data(shapes, rk=3, affine=np.eye(4)):
+    fmri_data = []
+    design_matrices = []
+    for i, shape in enumerate(shapes):
+        data = np.random.randn(*shape)
+        data[1:-1, 1:-1, 1:-1] += 100
+        fmri_data.append(Nifti1Image(data, affine))
+        design_matrices.append(pd.DataFrame(np.random.randn(shape[3], rk),
+                                            columns=['a', 'b', 'c']))
+    mask = Nifti1Image((np.random.rand(*shape[:3]) > .5).astype(np.int8),
+                       affine)
+    return mask, fmri_data, design_matrices
+
+
+def _write_fake_bold_img(file_path, shape, rk=3, affine=np.eye(4)):
+    data = np.random.randn(*shape)
+    data[1:-1, 1:-1, 1:-1] += 100
+    Nifti1Image(data, affine).to_filename(file_path)
+    return file_path
+
+
+def _basic_paradigm():
+    conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c1', 'c2', 'c2', 'c2']
+    onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
+    events = pd.DataFrame({'trial_type': conditions,
+                             'onset': onsets})
+    return events
+
+
+def _basic_confounds(length):
+    columns = ['RotX', 'RotY', 'RotZ', 'X', 'Y', 'Z']
+    data = np.random.rand(length, 6)
+    confounds = pd.DataFrame(data, columns=columns)
+    return confounds
+
+
+def create_fake_bids_dataset(base_dir='', n_sub=10, n_ses=2,
+                             tasks=['localizer', 'main'],
+                             n_runs=[1, 3], with_derivatives=True,
+                             with_confounds=True, no_session=False):
+    """Returns a fake bids dataset directory with dummy files
+
+    In the case derivatives are included, they come with two spaces and
+    variants. Spaces are 'MNI' and 'T1w'. Variants are 'some' and 'other'.
+    Only space 'T1w' include both variants.
+
+    Specifying no_sessions will only produce runs and files without the
+    optional session field. In this case n_ses will be ignored.
+    """
+    bids_path = os.path.join(base_dir, 'bids_dataset')
+    os.makedirs(bids_path)
+    # Create surface bids dataset
+    open(os.path.join(bids_path, 'README.txt'), 'w')
+    vox = 4
+    created_sessions = ['ses-%02d' % label for label in range(1, n_ses + 1)]
+    if no_session:
+        created_sessions = ['']
+    for subject in ['sub-%02d' % label for label in range(1, n_sub + 1)]:
+        for session in created_sessions:
+            subses_dir = os.path.join(bids_path, subject, session)
+            if session == 'ses-01' or session == '':
+                anat_path = os.path.join(subses_dir, 'anat')
+                os.makedirs(anat_path)
+                anat_file = os.path.join(anat_path, subject + '_T1w.nii.gz')
+                open(anat_file, 'w')
+            func_path = os.path.join(subses_dir, 'func')
+            os.makedirs(func_path)
+            for task, n_run in zip(tasks, n_runs):
+                for run in ['run-%02d' % label for label in range(1, n_run + 1)]:
+                    fields = [subject, session, 'task-' + task]
+                    if '' in fields:
+                        fields.remove('')
+                    file_id = '_'.join(fields)
+                    if n_run > 1:
+                        file_id += '_' + run
+                    bold_path = os.path.join(func_path, file_id + '_bold.nii.gz')
+                    _write_fake_bold_img(bold_path, [vox, vox, vox, 100])
+                    events_path = os.path.join(func_path, file_id +
+                                               '_events.tsv')
+                    _basic_paradigm().to_csv(events_path, sep='\t', index=None)
+                    param_path = os.path.join(func_path, file_id +
+                                              '_bold.json')
+                    with open(param_path, 'w') as param_file:
+                        json.dump({'RepetitionTime': 1.5}, param_file)
+
+    # Create derivatives files
+    if with_derivatives:
+        bids_path = os.path.join(base_dir, 'bids_dataset', 'derivatives')
+        os.makedirs(bids_path)
+        for subject in ['sub-%02d' % label for label in range(1, 11)]:
+            for session in created_sessions:
+                subses_dir = os.path.join(bids_path, subject, session)
+                func_path = os.path.join(subses_dir, 'func')
+                os.makedirs(func_path)
+                for task, n_run in zip(tasks, n_runs):
+                    for run in ['run-%02d' % label for label in range(1, n_run + 1)]:
+                        fields = [subject, session, 'task-' + task]
+                        if '' in fields:
+                            fields.remove('')
+                        file_id = '_'.join(fields)
+                        if n_run > 1:
+                            file_id += '_' + run
+                        preproc = file_id + '_bold_space-MNI_variant-some_preproc.nii.gz'
+                        preproc_path = os.path.join(func_path, preproc)
+                        _write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
+                        preproc = file_id + '_bold_space-T1w_variant-some_preproc.nii.gz'
+                        preproc_path = os.path.join(func_path, preproc)
+                        _write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
+                        preproc = file_id + '_bold_space-T1w_variant-other_preproc.nii.gz'
+                        preproc_path = os.path.join(func_path, preproc)
+                        _write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
+                        if with_confounds:
+                            confounds_path = os.path.join(func_path, file_id +
+                                                          '_confounds.tsv')
+                            _basic_confounds(100).to_csv(confounds_path,
+                                                         sep='\t', index=None)
+    return 'bids_dataset'

--- a/nistats/tests/test_first_level_model.py
+++ b/nistats/tests/test_first_level_model.py
@@ -31,15 +31,13 @@ from nistats.first_level_model import (first_level_models_from_bids,
                                        mean_scaling,
                                        run_glm,
                                        )
-
-from nistats.utils import (get_bids_files,
-                           )
-from nistats._utils.testing import (create_fake_bids_dataset,
-                                    generate_fake_fmri_data,
-                                    write_fake_fmri_data,
+from nistats.utils import get_bids_files
+from nistats._utils.testing import (_create_fake_bids_dataset,
+                                    _generate_fake_fmri_data,
+                                    _write_fake_fmri_data,
                                     )
 
-# This directory path
+
 BASEDIR = os.path.dirname(os.path.abspath(__file__))
 FUNCFILE = os.path.join(BASEDIR, 'functional.nii.gz')
 
@@ -47,7 +45,7 @@ FUNCFILE = os.path.join(BASEDIR, 'functional.nii.gz')
 def test_high_level_glm_one_session():
     # New API
     shapes, rk = [(7, 8, 9, 15)], 3
-    mask, fmri_data, design_matrices = generate_fake_fmri_data(shapes, rk)
+    mask, fmri_data, design_matrices = _generate_fake_fmri_data(shapes, rk)
 
     single_session_model = FirstLevelModel(mask=None).fit(
         fmri_data[0], design_matrices=design_matrices[0])
@@ -64,7 +62,7 @@ def test_high_level_glm_with_data():
     # New API
     with InTemporaryDirectory():
         shapes, rk = ((7, 8, 7, 15), (7, 8, 7, 16)), 3
-        mask, fmri_data, design_matrices = write_fake_fmri_data(shapes, rk)
+        mask, fmri_data, design_matrices = _write_fake_fmri_data(shapes, rk)
         multi_session_model = FirstLevelModel(mask=None).fit(
             fmri_data, design_matrices=design_matrices)
         n_voxels = multi_session_model.masker_.mask_img_.get_data().sum()
@@ -103,7 +101,7 @@ def test_high_level_glm_with_paths():
     # New API
     shapes, rk = ((7, 8, 7, 15), (7, 8, 7, 14)), 3
     with InTemporaryDirectory():
-        mask_file, fmri_files, design_files = write_fake_fmri_data(shapes, rk)
+        mask_file, fmri_files, design_files = _write_fake_fmri_data(shapes, rk)
         multi_session_model = FirstLevelModel(mask=None).fit(
             fmri_files, design_matrices=design_files)
         z_image = multi_session_model.compute_contrast(np.eye(rk)[1])
@@ -118,7 +116,7 @@ def test_high_level_glm_null_contrasts():
     # test that contrast computation is resilient to 0 values.
     # new API
     shapes, rk = ((7, 8, 7, 15), (7, 8, 7, 19)), 3
-    mask, fmri_data, design_matrices = generate_fake_fmri_data(shapes, rk)
+    mask, fmri_data, design_matrices = _generate_fake_fmri_data(shapes, rk)
 
     multi_session_model = FirstLevelModel(mask=None).fit(
         fmri_data, design_matrices=design_matrices)
@@ -173,7 +171,7 @@ def test_fmri_inputs():
     # Test processing of FMRI inputs
     with InTemporaryDirectory():
         shapes = ((7, 8, 9, 10),)
-        mask, FUNCFILE, _ = write_fake_fmri_data(shapes)
+        mask, FUNCFILE, _ = _write_fake_fmri_data(shapes)
         FUNCFILE = FUNCFILE[0]
         func_img = load(FUNCFILE)
         T = func_img.shape[-1]
@@ -223,7 +221,7 @@ def test_first_level_model_design_creation():
         # Test processing of FMRI inputs
     with InTemporaryDirectory():
         shapes = ((7, 8, 9, 10),)
-        mask, FUNCFILE, _ = write_fake_fmri_data(shapes)
+        mask, FUNCFILE, _ = _write_fake_fmri_data(shapes)
         FUNCFILE = FUNCFILE[0]
         func_img = load(FUNCFILE)
         # basic test based on basic_paradigm and glover hrf
@@ -250,7 +248,7 @@ def test_first_level_model_design_creation():
 def test_first_level_model_glm_computation():
     with InTemporaryDirectory():
         shapes = ((7, 8, 9, 10),)
-        mask, FUNCFILE, _ = write_fake_fmri_data(shapes)
+        mask, FUNCFILE, _ = _write_fake_fmri_data(shapes)
         FUNCFILE = FUNCFILE[0]
         func_img = load(FUNCFILE)
         # basic test based on basic_paradigm and glover hrf
@@ -275,7 +273,7 @@ def test_first_level_model_glm_computation():
 def test_first_level_glm_computation_with_memory_caching():
     with InTemporaryDirectory():
         shapes = ((7, 8, 9, 10),)
-        mask, FUNCFILE, _ = write_fake_fmri_data(shapes)
+        mask, FUNCFILE, _ = _write_fake_fmri_data(shapes)
         FUNCFILE = FUNCFILE[0]
         func_img = load(FUNCFILE)
         # initialize FirstLevelModel with memory option enabled
@@ -293,7 +291,7 @@ def test_first_level_glm_computation_with_memory_caching():
 def test_first_level_model_contrast_computation():
     with InTemporaryDirectory():
         shapes = ((7, 8, 9, 10),)
-        mask, FUNCFILE, _ = write_fake_fmri_data(shapes)
+        mask, FUNCFILE, _ = _write_fake_fmri_data(shapes)
         FUNCFILE = FUNCFILE[0]
         func_img = load(FUNCFILE)
         # basic test based on basic_paradigm and glover hrf
@@ -339,7 +337,7 @@ def test_first_level_model_contrast_computation():
 
 def test_first_level_models_from_bids():
     with InTemporaryDirectory():
-        bids_path = create_fake_bids_dataset(n_sub=10, n_ses=2,
+        bids_path = _create_fake_bids_dataset(n_sub=10, n_ses=2,
                                              tasks=['localizer', 'main'],
                                              n_runs=[1, 3])
         # test arguments are provided correctly
@@ -390,7 +388,7 @@ def test_first_level_models_from_bids():
 
         # check runs are not repeated when ses field is not used
         shutil.rmtree(bids_path)
-        bids_path = create_fake_bids_dataset(n_sub=10, n_ses=1,
+        bids_path = _create_fake_bids_dataset(n_sub=10, n_ses=1,
                                              tasks=['localizer', 'main'],
                                              n_runs=[1, 3], no_session=True)
         # test repeated run tag error when run tag is in filenames and not ses

--- a/nistats/tests/test_first_level_model.py
+++ b/nistats/tests/test_first_level_model.py
@@ -32,43 +32,15 @@ from nistats.first_level_model import (first_level_models_from_bids,
                                        run_glm,
                                        )
 
-
-from nistats.tests.test_utils import create_fake_bids_dataset
-from nistats.utils import get_bids_files
-
+from nistats.utils import (create_fake_bids_dataset,
+                           get_bids_files,
+                           generate_fake_fmri_data,
+                           write_fake_fmri_data,
+                           )
 
 # This directory path
 BASEDIR = os.path.dirname(os.path.abspath(__file__))
 FUNCFILE = os.path.join(BASEDIR, 'functional.nii.gz')
-
-
-def write_fake_fmri_data(shapes, rk=3, affine=np.eye(4)):
-    mask_file, fmri_files, design_files = 'mask.nii', [], []
-    for i, shape in enumerate(shapes):
-        fmri_files.append('fmri_run%d.nii' % i)
-        data = np.random.randn(*shape)
-        data[1:-1, 1:-1, 1:-1] += 100
-        Nifti1Image(data, affine).to_filename(fmri_files[-1])
-        design_files.append('dmtx_%d.csv' % i)
-        pd.DataFrame(np.random.randn(shape[3], rk),
-                     columns=['', '', '']).to_csv(design_files[-1])
-    Nifti1Image((np.random.rand(*shape[:3]) > .5).astype(np.int8),
-                affine).to_filename(mask_file)
-    return mask_file, fmri_files, design_files
-
-
-def generate_fake_fmri_data(shapes, rk=3, affine=np.eye(4)):
-    fmri_data = []
-    design_matrices = []
-    for i, shape in enumerate(shapes):
-        data = np.random.randn(*shape)
-        data[1:-1, 1:-1, 1:-1] += 100
-        fmri_data.append(Nifti1Image(data, affine))
-        design_matrices.append(pd.DataFrame(np.random.randn(shape[3], rk),
-                                            columns=['a', 'b', 'c']))
-    mask = Nifti1Image((np.random.rand(*shape[:3]) > .5).astype(np.int8),
-                       affine)
-    return mask, fmri_data, design_matrices
 
 
 def test_high_level_glm_one_session():

--- a/nistats/tests/test_first_level_model.py
+++ b/nistats/tests/test_first_level_model.py
@@ -32,11 +32,12 @@ from nistats.first_level_model import (first_level_models_from_bids,
                                        run_glm,
                                        )
 
-from nistats.utils import (create_fake_bids_dataset,
-                           get_bids_files,
-                           generate_fake_fmri_data,
-                           write_fake_fmri_data,
+from nistats.utils import (get_bids_files,
                            )
+from nistats._utils.testing import (create_fake_bids_dataset,
+                                    generate_fake_fmri_data,
+                                    write_fake_fmri_data,
+                                    )
 
 # This directory path
 BASEDIR = os.path.dirname(os.path.abspath(__file__))

--- a/nistats/tests/test_second_level_model.py
+++ b/nistats/tests/test_second_level_model.py
@@ -27,7 +27,7 @@ from nistats.first_level_model import (FirstLevelModel,
                                        run_glm,
                                        )
 from nistats.second_level_model import SecondLevelModel
-from nistats._utils.testing import write_fake_fmri_data
+from nistats._utils.testing import _write_fake_fmri_data
 
 # This directory path
 BASEDIR = os.path.dirname(os.path.abspath(__file__))
@@ -37,7 +37,7 @@ FUNCFILE = os.path.join(BASEDIR, 'functional.nii.gz')
 def test_high_level_glm_with_paths():
     with InTemporaryDirectory():
         shapes = ((7, 8, 9, 1),)
-        mask, FUNCFILE, _ = write_fake_fmri_data(shapes)
+        mask, FUNCFILE, _ = _write_fake_fmri_data(shapes)
         FUNCFILE = FUNCFILE[0]
         func_img = load(FUNCFILE)
         # Ordinary Least Squares case
@@ -64,7 +64,7 @@ def test_fmri_inputs():
         p, q = 80, 10
         X = np.random.randn(p, q)
         shapes = ((7, 8, 9, 10),)
-        mask, FUNCFILE, _ = write_fake_fmri_data(shapes)
+        mask, FUNCFILE, _ = _write_fake_fmri_data(shapes)
         FUNCFILE = FUNCFILE[0]
         func_img = load(FUNCFILE)
         T = func_img.shape[-1]
@@ -78,7 +78,7 @@ def test_fmri_inputs():
         flms = [flm, flm, flm]
         # prepare correct input dataframe and lists
         shapes = ((7, 8, 9, 1),)
-        _, FUNCFILE, _ = write_fake_fmri_data(shapes)
+        _, FUNCFILE, _ = _write_fake_fmri_data(shapes)
         FUNCFILE = FUNCFILE[0]
 
         dfcols = ['subject_label', 'map_name', 'effects_map_path']
@@ -141,7 +141,7 @@ def _first_level_dataframe():
 def test_second_level_model_glm_computation():
     with InTemporaryDirectory():
         shapes = ((7, 8, 9, 1),)
-        mask, FUNCFILE, _ = write_fake_fmri_data(shapes)
+        mask, FUNCFILE, _ = _write_fake_fmri_data(shapes)
         FUNCFILE = FUNCFILE[0]
         func_img = load(FUNCFILE)
         # Ordinary Least Squares case
@@ -163,7 +163,7 @@ def test_second_level_model_glm_computation():
 def test_second_level_model_contrast_computation():
     with InTemporaryDirectory():
         shapes = ((7, 8, 9, 1),)
-        mask, FUNCFILE, _ = write_fake_fmri_data(shapes)
+        mask, FUNCFILE, _ = _write_fake_fmri_data(shapes)
         FUNCFILE = FUNCFILE[0]
         func_img = load(FUNCFILE)
         # Ordinary Least Squares case
@@ -204,7 +204,7 @@ def test_second_level_model_contrast_computation():
 def test_second_level_model_contrast_computation_with_memory_caching():
     with InTemporaryDirectory():
         shapes = ((7, 8, 9, 1),)
-        mask, FUNCFILE, _ = write_fake_fmri_data(shapes)
+        mask, FUNCFILE, _ = _write_fake_fmri_data(shapes)
         FUNCFILE = FUNCFILE[0]
         func_img = load(FUNCFILE)
         # Ordinary Least Squares case

--- a/nistats/tests/test_second_level_model.py
+++ b/nistats/tests/test_second_level_model.py
@@ -27,26 +27,11 @@ from nistats.first_level_model import (FirstLevelModel,
                                        run_glm,
                                        )
 from nistats.second_level_model import SecondLevelModel
-
+from nistats.utils import write_fake_fmri_data
 
 # This directory path
 BASEDIR = os.path.dirname(os.path.abspath(__file__))
 FUNCFILE = os.path.join(BASEDIR, 'functional.nii.gz')
-
-
-def write_fake_fmri_data(shapes, rk=3, affine=np.eye(4)):
-    mask_file, fmri_files, design_files = 'mask.nii', [], []
-    for i, shape in enumerate(shapes):
-        fmri_files.append('fmri_run%d.nii' % i)
-        data = np.random.randn(*shape)
-        data[1:-1, 1:-1, 1:-1] += 100
-        Nifti1Image(data, affine).to_filename(fmri_files[-1])
-        design_files.append('dmtx_%d.csv' % i)
-        pd.DataFrame(np.random.randn(shape[3], rk),
-                     columns=['', '', '']).to_csv(design_files[-1])
-    Nifti1Image((np.random.rand(*shape[:3]) > .5).astype(np.int8),
-                affine).to_filename(mask_file)
-    return mask_file, fmri_files, design_files
 
 
 def test_high_level_glm_with_paths():

--- a/nistats/tests/test_second_level_model.py
+++ b/nistats/tests/test_second_level_model.py
@@ -27,7 +27,7 @@ from nistats.first_level_model import (FirstLevelModel,
                                        run_glm,
                                        )
 from nistats.second_level_model import SecondLevelModel
-from nistats.utils import write_fake_fmri_data
+from nistats._utils.testing import write_fake_fmri_data
 
 # This directory path
 BASEDIR = os.path.dirname(os.path.abspath(__file__))

--- a/nistats/tests/test_utils.py
+++ b/nistats/tests/test_utils.py
@@ -29,7 +29,7 @@ from nistats.utils import (_check_run_tables,
                            positive_reciprocal,
                            z_score,
                            )
-from nistats._utils.testing import create_fake_bids_dataset
+from nistats._utils.testing import _create_fake_bids_dataset
 
 
 def test_full_rank():
@@ -124,7 +124,7 @@ def test_img_table_checks():
 
 def test_get_bids_files():
     with InTemporaryDirectory():
-        bids_path = create_fake_bids_dataset(n_sub=10, n_ses=2,
+        bids_path = _create_fake_bids_dataset(n_sub=10, n_ses=2,
                                              tasks=['localizer', 'main'],
                                              n_runs=[1, 3])
         # For each possible possible option of file selection we check

--- a/nistats/tests/test_utils.py
+++ b/nistats/tests/test_utils.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python
-import json
 import os
 
 import numpy as np
 import pandas as pd
 import scipy.linalg as spl
 
-from nibabel import Nifti1Image
 from nibabel.tmpdirs import InTemporaryDirectory
 from nilearn.datasets.tests import test_utils as tst
 from nose import with_setup
@@ -22,6 +20,7 @@ from scipy.stats import norm
 from nistats.utils import (_check_run_tables,
                            _check_and_load_tables,
                            _check_list_length_match,
+                           create_fake_bids_dataset,
                            full_rank,
                            get_bids_files,
                            get_design_from_fslmat,
@@ -121,111 +120,6 @@ def test_img_table_checks():
                   [np.array([0]), pd.DataFrame()], "")
     assert_raises(ValueError, _check_run_tables, [''] * 2,
                   ['.csv', pd.DataFrame()], "")
-
-
-def write_fake_bold_img(file_path, shape, rk=3, affine=np.eye(4)):
-    data = np.random.randn(*shape)
-    data[1:-1, 1:-1, 1:-1] += 100
-    Nifti1Image(data, affine).to_filename(file_path)
-    return file_path
-
-
-def basic_paradigm():
-    conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c1', 'c2', 'c2', 'c2']
-    onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
-    events = pd.DataFrame({'trial_type': conditions,
-                             'onset': onsets})
-    return events
-
-
-def basic_confounds(length):
-    columns = ['RotX', 'RotY', 'RotZ', 'X', 'Y', 'Z']
-    data = np.random.rand(length, 6)
-    confounds = pd.DataFrame(data, columns=columns)
-    return confounds
-
-
-def create_fake_bids_dataset(base_dir='', n_sub=10, n_ses=2,
-                             tasks=['localizer', 'main'],
-                             n_runs=[1, 3], with_derivatives=True,
-                             with_confounds=True, no_session=False):
-    """Returns a fake bids dataset directory with dummy files
-
-    In the case derivatives are included, they come with two spaces and
-    variants. Spaces are 'MNI' and 'T1w'. Variants are 'some' and 'other'.
-    Only space 'T1w' include both variants.
-
-    Specifying no_sessions will only produce runs and files without the
-    optional session field. In this case n_ses will be ignored.
-    """
-    bids_path = os.path.join(base_dir, 'bids_dataset')
-    os.makedirs(bids_path)
-    # Create surface bids dataset
-    open(os.path.join(bids_path, 'README.txt'), 'w')
-    vox = 4
-    created_sessions = ['ses-%02d' % label for label in range(1, n_ses + 1)]
-    if no_session:
-        created_sessions = ['']
-    for subject in ['sub-%02d' % label for label in range(1, n_sub + 1)]:
-        for session in created_sessions:
-            subses_dir = os.path.join(bids_path, subject, session)
-            if session == 'ses-01' or session == '':
-                anat_path = os.path.join(subses_dir, 'anat')
-                os.makedirs(anat_path)
-                anat_file = os.path.join(anat_path, subject + '_T1w.nii.gz')
-                open(anat_file, 'w')
-            func_path = os.path.join(subses_dir, 'func')
-            os.makedirs(func_path)
-            for task, n_run in zip(tasks, n_runs):
-                for run in ['run-%02d' % label for label in range(1, n_run + 1)]:
-                    fields = [subject, session, 'task-' + task]
-                    if '' in fields:
-                        fields.remove('')
-                    file_id = '_'.join(fields)
-                    if n_run > 1:
-                        file_id += '_' + run
-                    bold_path = os.path.join(func_path, file_id + '_bold.nii.gz')
-                    write_fake_bold_img(bold_path, [vox, vox, vox, 100])
-                    events_path = os.path.join(func_path, file_id +
-                                               '_events.tsv')
-                    basic_paradigm().to_csv(events_path, sep='\t', index=None)
-                    param_path = os.path.join(func_path, file_id +
-                                              '_bold.json')
-                    with open(param_path, 'w') as param_file:
-                        json.dump({'RepetitionTime': 1.5}, param_file)
-
-    # Create derivatives files
-    if with_derivatives:
-        bids_path = os.path.join(base_dir, 'bids_dataset', 'derivatives')
-        os.makedirs(bids_path)
-        for subject in ['sub-%02d' % label for label in range(1, 11)]:
-            for session in created_sessions:
-                subses_dir = os.path.join(bids_path, subject, session)
-                func_path = os.path.join(subses_dir, 'func')
-                os.makedirs(func_path)
-                for task, n_run in zip(tasks, n_runs):
-                    for run in ['run-%02d' % label for label in range(1, n_run + 1)]:
-                        fields = [subject, session, 'task-' + task]
-                        if '' in fields:
-                            fields.remove('')
-                        file_id = '_'.join(fields)
-                        if n_run > 1:
-                            file_id += '_' + run
-                        preproc = file_id + '_bold_space-MNI_variant-some_preproc.nii.gz'
-                        preproc_path = os.path.join(func_path, preproc)
-                        write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
-                        preproc = file_id + '_bold_space-T1w_variant-some_preproc.nii.gz'
-                        preproc_path = os.path.join(func_path, preproc)
-                        write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
-                        preproc = file_id + '_bold_space-T1w_variant-other_preproc.nii.gz'
-                        preproc_path = os.path.join(func_path, preproc)
-                        write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
-                        if with_confounds:
-                            confounds_path = os.path.join(func_path, file_id +
-                                                          '_confounds.tsv')
-                            basic_confounds(100).to_csv(confounds_path,
-                                                        sep='\t', index=None)
-    return 'bids_dataset'
 
 
 def test_get_bids_files():

--- a/nistats/tests/test_utils.py
+++ b/nistats/tests/test_utils.py
@@ -20,7 +20,6 @@ from scipy.stats import norm
 from nistats.utils import (_check_run_tables,
                            _check_and_load_tables,
                            _check_list_length_match,
-                           create_fake_bids_dataset,
                            full_rank,
                            get_bids_files,
                            get_design_from_fslmat,
@@ -30,6 +29,7 @@ from nistats.utils import (_check_run_tables,
                            positive_reciprocal,
                            z_score,
                            )
+from nistats._utils.testing import create_fake_bids_dataset
 
 
 def test_full_rank():

--- a/nistats/utils.py
+++ b/nistats/utils.py
@@ -477,14 +477,14 @@ def generate_fake_fmri_data(shapes, rk=3, affine=np.eye(4)):
     return mask, fmri_data, design_matrices
 
 
-def write_fake_bold_img(file_path, shape, rk=3, affine=np.eye(4)):
+def _write_fake_bold_img(file_path, shape, rk=3, affine=np.eye(4)):
     data = np.random.randn(*shape)
     data[1:-1, 1:-1, 1:-1] += 100
     Nifti1Image(data, affine).to_filename(file_path)
     return file_path
 
 
-def basic_paradigm():
+def _basic_paradigm():
     conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c1', 'c2', 'c2', 'c2']
     onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
     events = pd.DataFrame({'trial_type': conditions,
@@ -492,7 +492,7 @@ def basic_paradigm():
     return events
 
 
-def basic_confounds(length):
+def _basic_confounds(length):
     columns = ['RotX', 'RotY', 'RotZ', 'X', 'Y', 'Z']
     data = np.random.rand(length, 6)
     confounds = pd.DataFrame(data, columns=columns)
@@ -539,10 +539,10 @@ def create_fake_bids_dataset(base_dir='', n_sub=10, n_ses=2,
                     if n_run > 1:
                         file_id += '_' + run
                     bold_path = os.path.join(func_path, file_id + '_bold.nii.gz')
-                    write_fake_bold_img(bold_path, [vox, vox, vox, 100])
+                    _write_fake_bold_img(bold_path, [vox, vox, vox, 100])
                     events_path = os.path.join(func_path, file_id +
                                                '_events.tsv')
-                    basic_paradigm().to_csv(events_path, sep='\t', index=None)
+                    _basic_paradigm().to_csv(events_path, sep='\t', index=None)
                     param_path = os.path.join(func_path, file_id +
                                               '_bold.json')
                     with open(param_path, 'w') as param_file:
@@ -567,16 +567,16 @@ def create_fake_bids_dataset(base_dir='', n_sub=10, n_ses=2,
                             file_id += '_' + run
                         preproc = file_id + '_bold_space-MNI_variant-some_preproc.nii.gz'
                         preproc_path = os.path.join(func_path, preproc)
-                        write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
+                        _write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
                         preproc = file_id + '_bold_space-T1w_variant-some_preproc.nii.gz'
                         preproc_path = os.path.join(func_path, preproc)
-                        write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
+                        _write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
                         preproc = file_id + '_bold_space-T1w_variant-other_preproc.nii.gz'
                         preproc_path = os.path.join(func_path, preproc)
-                        write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
+                        _write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
                         if with_confounds:
                             confounds_path = os.path.join(func_path, file_id +
                                                           '_confounds.tsv')
-                            basic_confounds(100).to_csv(confounds_path,
-                                                        sep='\t', index=None)
+                            _basic_confounds(100).to_csv(confounds_path,
+                                                         sep='\t', index=None)
     return 'bids_dataset'

--- a/nistats/utils.py
+++ b/nistats/utils.py
@@ -4,6 +4,7 @@ Authors: Bertrand Thirion, Matthew Brett, 2015
 """
 import csv
 import glob
+import json
 import os
 import sys
 
@@ -13,6 +14,7 @@ import numpy as np
 import pandas as pd
 
 import scipy.linalg as spl
+from nibabel import Nifti1Image
 from scipy.stats import norm
 
 py3 = sys.version_info[0] >= 3
@@ -444,3 +446,137 @@ def get_design_from_fslmat(fsl_design_matrix_path, column_names=None):
     design_matrix = pd.DataFrame(design_matrix, columns=column_names)
 
     return design_matrix
+
+
+def write_fake_fmri_data(shapes, rk=3, affine=np.eye(4)):
+    mask_file, fmri_files, design_files = 'mask.nii', [], []
+    for i, shape in enumerate(shapes):
+        fmri_files.append('fmri_run%d.nii' % i)
+        data = np.random.randn(*shape)
+        data[1:-1, 1:-1, 1:-1] += 100
+        Nifti1Image(data, affine).to_filename(fmri_files[-1])
+        design_files.append('dmtx_%d.csv' % i)
+        pd.DataFrame(np.random.randn(shape[3], rk),
+                     columns=['', '', '']).to_csv(design_files[-1])
+    Nifti1Image((np.random.rand(*shape[:3]) > .5).astype(np.int8),
+                affine).to_filename(mask_file)
+    return mask_file, fmri_files, design_files
+
+
+def generate_fake_fmri_data(shapes, rk=3, affine=np.eye(4)):
+    fmri_data = []
+    design_matrices = []
+    for i, shape in enumerate(shapes):
+        data = np.random.randn(*shape)
+        data[1:-1, 1:-1, 1:-1] += 100
+        fmri_data.append(Nifti1Image(data, affine))
+        design_matrices.append(pd.DataFrame(np.random.randn(shape[3], rk),
+                                            columns=['a', 'b', 'c']))
+    mask = Nifti1Image((np.random.rand(*shape[:3]) > .5).astype(np.int8),
+                       affine)
+    return mask, fmri_data, design_matrices
+
+
+def write_fake_bold_img(file_path, shape, rk=3, affine=np.eye(4)):
+    data = np.random.randn(*shape)
+    data[1:-1, 1:-1, 1:-1] += 100
+    Nifti1Image(data, affine).to_filename(file_path)
+    return file_path
+
+
+def basic_paradigm():
+    conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c1', 'c2', 'c2', 'c2']
+    onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
+    events = pd.DataFrame({'trial_type': conditions,
+                             'onset': onsets})
+    return events
+
+
+def basic_confounds(length):
+    columns = ['RotX', 'RotY', 'RotZ', 'X', 'Y', 'Z']
+    data = np.random.rand(length, 6)
+    confounds = pd.DataFrame(data, columns=columns)
+    return confounds
+
+
+def create_fake_bids_dataset(base_dir='', n_sub=10, n_ses=2,
+                             tasks=['localizer', 'main'],
+                             n_runs=[1, 3], with_derivatives=True,
+                             with_confounds=True, no_session=False):
+    """Returns a fake bids dataset directory with dummy files
+
+    In the case derivatives are included, they come with two spaces and
+    variants. Spaces are 'MNI' and 'T1w'. Variants are 'some' and 'other'.
+    Only space 'T1w' include both variants.
+
+    Specifying no_sessions will only produce runs and files without the
+    optional session field. In this case n_ses will be ignored.
+    """
+    bids_path = os.path.join(base_dir, 'bids_dataset')
+    os.makedirs(bids_path)
+    # Create surface bids dataset
+    open(os.path.join(bids_path, 'README.txt'), 'w')
+    vox = 4
+    created_sessions = ['ses-%02d' % label for label in range(1, n_ses + 1)]
+    if no_session:
+        created_sessions = ['']
+    for subject in ['sub-%02d' % label for label in range(1, n_sub + 1)]:
+        for session in created_sessions:
+            subses_dir = os.path.join(bids_path, subject, session)
+            if session == 'ses-01' or session == '':
+                anat_path = os.path.join(subses_dir, 'anat')
+                os.makedirs(anat_path)
+                anat_file = os.path.join(anat_path, subject + '_T1w.nii.gz')
+                open(anat_file, 'w')
+            func_path = os.path.join(subses_dir, 'func')
+            os.makedirs(func_path)
+            for task, n_run in zip(tasks, n_runs):
+                for run in ['run-%02d' % label for label in range(1, n_run + 1)]:
+                    fields = [subject, session, 'task-' + task]
+                    if '' in fields:
+                        fields.remove('')
+                    file_id = '_'.join(fields)
+                    if n_run > 1:
+                        file_id += '_' + run
+                    bold_path = os.path.join(func_path, file_id + '_bold.nii.gz')
+                    write_fake_bold_img(bold_path, [vox, vox, vox, 100])
+                    events_path = os.path.join(func_path, file_id +
+                                               '_events.tsv')
+                    basic_paradigm().to_csv(events_path, sep='\t', index=None)
+                    param_path = os.path.join(func_path, file_id +
+                                              '_bold.json')
+                    with open(param_path, 'w') as param_file:
+                        json.dump({'RepetitionTime': 1.5}, param_file)
+
+    # Create derivatives files
+    if with_derivatives:
+        bids_path = os.path.join(base_dir, 'bids_dataset', 'derivatives')
+        os.makedirs(bids_path)
+        for subject in ['sub-%02d' % label for label in range(1, 11)]:
+            for session in created_sessions:
+                subses_dir = os.path.join(bids_path, subject, session)
+                func_path = os.path.join(subses_dir, 'func')
+                os.makedirs(func_path)
+                for task, n_run in zip(tasks, n_runs):
+                    for run in ['run-%02d' % label for label in range(1, n_run + 1)]:
+                        fields = [subject, session, 'task-' + task]
+                        if '' in fields:
+                            fields.remove('')
+                        file_id = '_'.join(fields)
+                        if n_run > 1:
+                            file_id += '_' + run
+                        preproc = file_id + '_bold_space-MNI_variant-some_preproc.nii.gz'
+                        preproc_path = os.path.join(func_path, preproc)
+                        write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
+                        preproc = file_id + '_bold_space-T1w_variant-some_preproc.nii.gz'
+                        preproc_path = os.path.join(func_path, preproc)
+                        write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
+                        preproc = file_id + '_bold_space-T1w_variant-other_preproc.nii.gz'
+                        preproc_path = os.path.join(func_path, preproc)
+                        write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
+                        if with_confounds:
+                            confounds_path = os.path.join(func_path, file_id +
+                                                          '_confounds.tsv')
+                            basic_confounds(100).to_csv(confounds_path,
+                                                        sep='\t', index=None)
+    return 'bids_dataset'

--- a/nistats/utils.py
+++ b/nistats/utils.py
@@ -4,7 +4,6 @@ Authors: Bertrand Thirion, Matthew Brett, 2015
 """
 import csv
 import glob
-import json
 import os
 import sys
 
@@ -14,7 +13,6 @@ import numpy as np
 import pandas as pd
 
 import scipy.linalg as spl
-from nibabel import Nifti1Image
 from scipy.stats import norm
 
 py3 = sys.version_info[0] >= 3
@@ -446,137 +444,3 @@ def get_design_from_fslmat(fsl_design_matrix_path, column_names=None):
     design_matrix = pd.DataFrame(design_matrix, columns=column_names)
 
     return design_matrix
-
-
-def write_fake_fmri_data(shapes, rk=3, affine=np.eye(4)):
-    mask_file, fmri_files, design_files = 'mask.nii', [], []
-    for i, shape in enumerate(shapes):
-        fmri_files.append('fmri_run%d.nii' % i)
-        data = np.random.randn(*shape)
-        data[1:-1, 1:-1, 1:-1] += 100
-        Nifti1Image(data, affine).to_filename(fmri_files[-1])
-        design_files.append('dmtx_%d.csv' % i)
-        pd.DataFrame(np.random.randn(shape[3], rk),
-                     columns=['', '', '']).to_csv(design_files[-1])
-    Nifti1Image((np.random.rand(*shape[:3]) > .5).astype(np.int8),
-                affine).to_filename(mask_file)
-    return mask_file, fmri_files, design_files
-
-
-def generate_fake_fmri_data(shapes, rk=3, affine=np.eye(4)):
-    fmri_data = []
-    design_matrices = []
-    for i, shape in enumerate(shapes):
-        data = np.random.randn(*shape)
-        data[1:-1, 1:-1, 1:-1] += 100
-        fmri_data.append(Nifti1Image(data, affine))
-        design_matrices.append(pd.DataFrame(np.random.randn(shape[3], rk),
-                                            columns=['a', 'b', 'c']))
-    mask = Nifti1Image((np.random.rand(*shape[:3]) > .5).astype(np.int8),
-                       affine)
-    return mask, fmri_data, design_matrices
-
-
-def _write_fake_bold_img(file_path, shape, rk=3, affine=np.eye(4)):
-    data = np.random.randn(*shape)
-    data[1:-1, 1:-1, 1:-1] += 100
-    Nifti1Image(data, affine).to_filename(file_path)
-    return file_path
-
-
-def _basic_paradigm():
-    conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c1', 'c2', 'c2', 'c2']
-    onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
-    events = pd.DataFrame({'trial_type': conditions,
-                             'onset': onsets})
-    return events
-
-
-def _basic_confounds(length):
-    columns = ['RotX', 'RotY', 'RotZ', 'X', 'Y', 'Z']
-    data = np.random.rand(length, 6)
-    confounds = pd.DataFrame(data, columns=columns)
-    return confounds
-
-
-def create_fake_bids_dataset(base_dir='', n_sub=10, n_ses=2,
-                             tasks=['localizer', 'main'],
-                             n_runs=[1, 3], with_derivatives=True,
-                             with_confounds=True, no_session=False):
-    """Returns a fake bids dataset directory with dummy files
-
-    In the case derivatives are included, they come with two spaces and
-    variants. Spaces are 'MNI' and 'T1w'. Variants are 'some' and 'other'.
-    Only space 'T1w' include both variants.
-
-    Specifying no_sessions will only produce runs and files without the
-    optional session field. In this case n_ses will be ignored.
-    """
-    bids_path = os.path.join(base_dir, 'bids_dataset')
-    os.makedirs(bids_path)
-    # Create surface bids dataset
-    open(os.path.join(bids_path, 'README.txt'), 'w')
-    vox = 4
-    created_sessions = ['ses-%02d' % label for label in range(1, n_ses + 1)]
-    if no_session:
-        created_sessions = ['']
-    for subject in ['sub-%02d' % label for label in range(1, n_sub + 1)]:
-        for session in created_sessions:
-            subses_dir = os.path.join(bids_path, subject, session)
-            if session == 'ses-01' or session == '':
-                anat_path = os.path.join(subses_dir, 'anat')
-                os.makedirs(anat_path)
-                anat_file = os.path.join(anat_path, subject + '_T1w.nii.gz')
-                open(anat_file, 'w')
-            func_path = os.path.join(subses_dir, 'func')
-            os.makedirs(func_path)
-            for task, n_run in zip(tasks, n_runs):
-                for run in ['run-%02d' % label for label in range(1, n_run + 1)]:
-                    fields = [subject, session, 'task-' + task]
-                    if '' in fields:
-                        fields.remove('')
-                    file_id = '_'.join(fields)
-                    if n_run > 1:
-                        file_id += '_' + run
-                    bold_path = os.path.join(func_path, file_id + '_bold.nii.gz')
-                    _write_fake_bold_img(bold_path, [vox, vox, vox, 100])
-                    events_path = os.path.join(func_path, file_id +
-                                               '_events.tsv')
-                    _basic_paradigm().to_csv(events_path, sep='\t', index=None)
-                    param_path = os.path.join(func_path, file_id +
-                                              '_bold.json')
-                    with open(param_path, 'w') as param_file:
-                        json.dump({'RepetitionTime': 1.5}, param_file)
-
-    # Create derivatives files
-    if with_derivatives:
-        bids_path = os.path.join(base_dir, 'bids_dataset', 'derivatives')
-        os.makedirs(bids_path)
-        for subject in ['sub-%02d' % label for label in range(1, 11)]:
-            for session in created_sessions:
-                subses_dir = os.path.join(bids_path, subject, session)
-                func_path = os.path.join(subses_dir, 'func')
-                os.makedirs(func_path)
-                for task, n_run in zip(tasks, n_runs):
-                    for run in ['run-%02d' % label for label in range(1, n_run + 1)]:
-                        fields = [subject, session, 'task-' + task]
-                        if '' in fields:
-                            fields.remove('')
-                        file_id = '_'.join(fields)
-                        if n_run > 1:
-                            file_id += '_' + run
-                        preproc = file_id + '_bold_space-MNI_variant-some_preproc.nii.gz'
-                        preproc_path = os.path.join(func_path, preproc)
-                        _write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
-                        preproc = file_id + '_bold_space-T1w_variant-some_preproc.nii.gz'
-                        preproc_path = os.path.join(func_path, preproc)
-                        _write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
-                        preproc = file_id + '_bold_space-T1w_variant-other_preproc.nii.gz'
-                        preproc_path = os.path.join(func_path, preproc)
-                        _write_fake_bold_img(preproc_path, [vox, vox, vox, 100])
-                        if with_confounds:
-                            confounds_path = os.path.join(func_path, file_id +
-                                                          '_confounds.tsv')
-                            _basic_confounds(100).to_csv(confounds_path,
-                                                         sep='\t', index=None)
-    return 'bids_dataset'


### PR DESCRIPTION
 - Functions moved from /tests/test_first_level_model.py ino /nistats/utils.py:
   - write_fake_fmri_data()
   - generate_fake_fmri_data()
 - Functions moved from /tests/test_utils.py into /nistats/utils.py (some have been renamed):
   - write_fake_bold_img()  -->  _write_fake_bold_img()  
   - basic_paradigm()  -->  _basic_paradigm()
   - basic_confounds()  -->  _basic_confounds()
   - create_fake_bids_dataset()
 - Duplicate function removed from /tests/test_second_level_model.py:
   - write_fake_fmri_data()