### PR TITLE
fetch_surf_fsaverage5 -> fetch_surf_fsaverage

### DIFF
--- a/examples/02_first_level_models/plot_localizer_surface_analysis.py
+++ b/examples/02_first_level_models/plot_localizer_surface_analysis.py
@@ -57,7 +57,7 @@ events = pd.read_table(events_file)
 # software.
 
 import nilearn
-fsaverage = nilearn.datasets.fetch_surf_fsaverage5()
+fsaverage = nilearn.datasets.fetch_surf_fsaverage()
 
 #########################################################################
 # The projection function simply takes the fMRI data and the mesh.


### PR DESCRIPTION
`fetch_surf_fsaverage5` has been deprecated in nilearn and replaced with `fetch_surf_fsaverage`, which can fetch either fsaverage or fsaverage5, fsaverage5 (the low-resolution mesh) being the default