### PR TITLE
[NOMRG] add xml reports

### DIFF
--- a/nistats/reporting/report_template.xml
+++ b/nistats/reporting/report_template.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nistats:report xmlns:nistats="https://nistats.github.io">
+    <nistats:title></nistats:title>
+    <nistats:model_info></nistats:model_info>
+    <nistats:contrast_list></nistats:contrast_list>
+    <nistats:design_matrices></nistats:design_matrices>
+</nistats:report>

--- a/nistats/reporting/report_to_html.xsl
+++ b/nistats/reporting/report_to_html.xsl
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:transform version="1.0"
+               xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+               xmlns:svg="http://www.w3.org/2000/svg"
+               xmlns:xhtml="http://www.w3.org/1999/xhtml"
+               xmlns="http://www.w3.org/1999/xhtml"
+               xmlns:nistats="https://nistats.github.io" >
+  <xsl:output method="xhtml" encoding="UTF-8" />
+  <xsl:strip-space elements="*"/>
+
+  <xsl:template match="text()" />
+
+  <xsl:template match="/">
+    <html lang="en">
+      <head>
+        <title><xsl:value-of select="/nistats:report/nistats:title/text()"/></title>
+        <meta charset="UTF-8"/>
+        <style>
+          table {
+            border-collapse: collapse;
+          }
+
+          table, th, td {
+            border: 1px solid black;
+          }
+        </style>
+      </head>
+      <body>
+        <div>
+          <xsl:apply-templates/>
+        </div>
+      </body>
+    </html>
+  </xsl:template>
+
+  <xsl:template match="nistats:title">
+    <h1><xsl:value-of select="text()"/></h1>
+  </xsl:template>
+
+  <xsl:template match="nistats:model_parameters">
+    <div>
+      <h2>model parameters</h2>
+      <p>
+      <xsl:for-each select="nistats:model_parameter">
+        <span>
+          <xsl:attribute name="title">description: "<xsl:value-of
+            select="nistats:parameter_description"/>"</xsl:attribute>
+          <b><xsl:value-of select="nistats:parameter_name"/>: </b><xsl:value-of
+          select="nistats:parameter_value"/>
+        </span>
+        <br/>
+      </xsl:for-each>
+      </p>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="nistats:contrast">
+    <hr/>
+    <div>
+      <h2>Contrast: <xsl:value-of select="nistats:contrast_name"/></h2>
+      <p>Statistic type: <xsl:value-of select="nistats:statistic_type"/></p>
+      <xsl:apply-templates />
+    </div>
+  </xsl:template>
+
+  <xsl:template match="nistats:clusters_table">
+    <h3>Peak activations</h3>
+    <xsl:apply-templates select="table" mode="pandas-table" />
+  </xsl:template>
+
+  <xsl:template match="svg:svg">
+    <xsl:copy-of select="."/>
+  </xsl:template>
+
+  <xsl:template match="nistats:design_matrices">
+    <hr/>
+    <div>
+      <h2>Design matrices</h2>
+      <xsl:for-each select="nistats:design_matrix">
+        <h3>Run <xsl:value-of select="position()"/></h3>
+        <xsl:apply-templates select="svg:svg"/>
+        <!-- <xsl:apply-templates select="table" mode="pandas-table"/> -->
+      </xsl:for-each>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="*" mode="pandas-table">
+    <xsl:element name="{local-name()}" namespace="http://www.w3.org/1999/xhtml">
+      <xsl:apply-templates select="@*|node()" mode="pandas-table"/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="@*" mode="pandas-table">
+    <xsl:attribute name="{name()}"><xsl:value-of select="."/></xsl:attribute>
+  </xsl:template>
+
+  <xsl:template match="@border" mode="pandas-table"/>
+
+</xsl:transform>

--- a/nistats/reporting/reporting_examples/example_report.py
+++ b/nistats/reporting/reporting_examples/example_report.py
@@ -1,0 +1,53 @@
+from sklearn.utils import Bunch
+import joblib
+from nistats.datasets import fetch_bids_langloc_dataset
+from nistats.first_level_model import first_level_models_from_bids
+from nistats.reporting import xml_reports
+
+MEMORY = joblib.Memory('/tmp/nistats_cache')
+
+
+@MEMORY.cache
+def get_model():
+    data_dir, _ = fetch_bids_langloc_dataset()
+
+    task_label = 'languagelocalizer'
+    space_label = 'MNI152nonlin2009aAsym'
+    (models, models_run_imgs,
+     models_events, models_confounds) = first_level_models_from_bids(
+        data_dir, task_label, space_label,
+        img_filters=[('variant', 'smoothResamp')])
+
+    model = models[0]
+    model.signal_scaling = False
+    activations = models_run_imgs[0][0]
+    events = models_events[0][0]
+    confounds = models_confounds[0][0]
+
+    model.fit(activations, events, confounds)
+    return model
+
+
+model = get_model()
+
+xml, html = xml_reports.make_report(
+    model, ['language - string', 'string - language'])
+
+xml = xml_reports.etree.tostring(
+    xml, pretty_print=True,
+    xml_declaration=True, encoding='utf-8').decode('utf-8')
+
+html = xml_reports.etree.tostring(
+    html, pretty_print=False,
+    xml_declaration=True, encoding='utf-8').decode('utf-8')
+
+with open('/tmp/report.xml', 'w') as f:
+    f.write(xml)
+
+with open('/tmp/report.xhtml', 'w') as f:
+    f.write(html)
+
+with open('/tmp/report.html', 'w') as f:
+    f.write(html)
+
+print('reports in /tmp/report.xml, /tmp/report.xhtml, /tmp/report.html')

--- a/nistats/reporting/xml_reports.py
+++ b/nistats/reporting/xml_reports.py
@@ -1,0 +1,121 @@
+import io
+import pathlib
+import random
+
+from lxml import etree
+from lxml.builder import ElementMaker
+
+from matplotlib import pyplot as plt
+import matplotlib as mpl
+
+from nilearn import plotting, input_data, datasets
+
+from nistats.thresholding import fdr_threshold
+from nistats.reporting import plot_design_matrix
+from nistats.reporting import plot_design_matrix, get_clusters_table
+
+
+NSMAP = {'nistats': 'https://nistats.github.io',
+         'xlink': 'http://www.w3.org/1999/xlink'}
+
+NS = ElementMaker(namespace="https://nistats.github.io",
+                  nsmap={'nistats': "https://nistats.github.io"})
+
+
+def get_report_template():
+    template_path = str(pathlib.Path(__file__).parent / 'report_template.xml')
+    return etree.parse(template_path)
+
+
+def get_stylesheet(stylesheet_name):
+    xsl_path = str(pathlib.Path(__file__).parent / stylesheet_name)
+    return etree.XSLT(etree.parse(xsl_path))
+
+
+def get_masker(mask_img=None):
+    if mask_img is None:
+        mask_img = datasets.load_mni152_brain_mask()
+    return input_data.NiftiMasker(mask_img).fit([])
+
+
+def clean_mpl_svg_ids(svg, fig_id=None):
+    if fig_id is None:
+        fig_id = 'f_{}'.format(random.randint(0, int(1e6)))
+    fig_id = str(fig_id)
+    elems_with_id = svg.xpath('//*[@id]')
+    for elem in elems_with_id:
+        eid = elem.attrib['id']
+        elem.attrib['id'] = '{}_{}'.format(fig_id, eid)
+        refs = svg.xpath(
+            '//*[@xlink:href = "#{}"]'.format(eid), namespaces=NSMAP)
+        for ref in refs:
+            ref.attrib['{http://www.w3.org/1999/xlink}href'
+                       ] = '#{}_{}'.format(fig_id, eid)
+    return svg
+
+
+def fig_to_svg(fig=None, fig_id=None):
+    if fig is None:
+        fig = plt.gcf()
+    buf = io.BytesIO()
+    try:
+        with mpl.rc_context(rc={'svg.fonttype': 'none'}):
+            fig.savefig(buf, format='svg')
+            buf.seek(0)
+            svg = etree.fromstring(buf.read())
+    finally:
+        buf.close()
+    return clean_mpl_svg_ids(svg)
+
+
+def report_contrast(model, contrast):
+    stat_map = model.compute_contrast(contrast)
+    masker = get_masker()
+    data = masker.transform(stat_map)
+    threshold = fdr_threshold(data, .05)
+    cluster_table = etree.XML(
+        get_clusters_table(stat_map, threshold, 15).to_html(index=False))
+    stat_map = masker.inverse_transform(data)
+    plotting.plot_stat_map(stat_map, threshold=threshold)
+    img = fig_to_svg()
+    plt.close('all')
+    return NS.contrast(
+        NS.contrast_name(contrast),
+        NS.statistic_type("Z"),
+        NS.stat_map_plot(img),
+        NS.clusters_table(cluster_table)
+    )
+
+
+def report_model_params(model):
+    parts = [NS.model_parameter(NS.parameter_name(k),
+                                NS.parameter_value(str(v)),
+                                NS.parameter_description(k))
+             for (k, v) in model.__dict__.items()
+             if not k.endswith('_')]
+    return NS.model_parameters(*parts)
+
+
+def report_design_matrices(model):
+    design = model.design_matrices_[0]
+    table = etree.XML(design.to_html())
+    plot_design_matrix(model.design_matrices_[0])
+    img = fig_to_svg()
+    return NS.design_matrix(table, img)
+
+
+def make_report(model, contrasts):
+    tree = get_report_template()
+    tree.xpath(
+        'nistats:title', namespaces=NSMAP)[0].text = 'Nistats Report'
+    tree.xpath(
+        'nistats:model_info', namespaces=NSMAP)[0].append(
+            report_model_params(model))
+    tree.xpath(
+        'nistats:design_matrices', namespaces=NSMAP)[0].append(
+            report_design_matrices(model))
+    for contrast in contrasts:
+        tree.xpath('nistats:contrast_list', namespaces=NSMAP
+                   )[0].append(report_contrast(model, contrast))
+    transform = get_stylesheet('report_to_html.xsl')
+    return tree, transform(tree)


### PR DESCRIPTION
this branch is not meant to be merged but just try a few things and help
discussion around #352.

here reports are generated as XML, which makes it easy to store a lot of
information (this is just a toy prototype) that can be easily validated (e.g. in
tests) for example with schemas, and reused.

xslt is used to provide human-readable views of the reports.

in other projects I have found that the pattern (info stored in xml + views
generated with XSLT + css to make them pretty) can be very efficient.

things that can be reused in #352:

- even if not using xml, lxml (which can work with html) can be useful to
  construct the reports

- store matplotlib figures as svg rather than binary formats such as png. note:
  to generate valid xhtml make sure ids of elements generated by matplotlib are
  actually unique in the document by changing them in the svg.

- remove deprecated "border" attribute written by pandas in html tables