### PR TITLE
Add support for explicit fixed effects

### DIFF
--- a/nistats/second_level_model.py
+++ b/nistats/second_level_model.py
@@ -253,6 +253,7 @@ def _learn_masker(model, second_level_input):
     else:
         # In this case design matrix had to be provided
         sample_map = mean_img(second_level_input)
+        subjects_label = None
 
     # Learn the mask. Assume the first level imgs have been masked.
     if not isinstance(model.mask_img, NiftiMasker):
@@ -601,8 +602,9 @@ class FixedEffectsModel(BaseEstimator, TransformerMixin, CacheMixin):
         if self.verbose > 0:
             sys.stderr.write("Preparing fixed effects model")
 
-        if not isinstance(effect_inputs[0], Nifti1Image):
-            raise ValueError("Input must be list of nifti images")
+        if not isinstance(effect_inputs[0], (str, Nifti1Image)):
+            raise ValueError("Input must be list of nifti images, or "
+                             "paths to images")
 
         self.masker_, subjects_label = _learn_masker(self, effect_inputs)
 
@@ -642,9 +644,9 @@ class FixedEffectsModel(BaseEstimator, TransformerMixin, CacheMixin):
         _check_output_type(output_type, valid_types)
 
         # Mask inputs
-        masked_effects = self.masker_.transform(self._effect_inputs_)
+        masked_effects = self.masker_.transform(self.effect_inputs_)
         masked_effects = np.split(masked_effects, masked_effects.shape[0])
-        masked_vars = self.masker_.transform(self._variance_inputs_)
+        masked_vars = self.masker_.transform(self.variance_inputs_)
         masked_vars = np.split(masked_vars, masked_vars.shape[0])
 
         # Compute contrasts


### PR DESCRIPTION
This is adds a class `FixedEffectsModel` which computes fixed effects statistics given matching lists of `effect_maps` and `variance_maps` nifti-images or paths. 

The background for doing this is that in `fitlins`, we compute each step in a multi-level model separately. Nistats already supports fixed-effects for muli-session designs but only as part of `FirstLevelModel`, which is not flexible enough for our purposes. 

I emulated `SecondLevelModel`, and abstracted the logic for learning a mask from inputs into a function `_learn_masker` that is used by both classes. 

Given how much of the logic is repeated, it would make sense to abstract more of it into functions, or to make a class which both `SecondLevel` and `FixedEffects` models abstract from, which includes this shared logic. 

Also, I wasn't sure if it would be possible to support other types of inputs (e.g. pandas df), so I only added suppots for nifti images, or paths to images. Need to also add memory caching for the fixed-effects contrast computation, and potentially abstract that logic for use by `FirstLevelModel`.

Closes #281