### PR TITLE
[MRG] remove file local variables

### DIFF
--- a/nistats/design_matrix.py
+++ b/nistats/design_matrix.py
@@ -1,5 +1,3 @@
-# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
-# vi: set ft=python sts=4 ts=4 sw=4 et:
 """
 This module implements fMRI Design Matrix creation.
 

--- a/nistats/experimental_paradigm.py
+++ b/nistats/experimental_paradigm.py
@@ -1,5 +1,3 @@
-# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
-# vi: set ft=python sts=4 ts=4 sw=4 et:
 """
 An experimental protocol is handled as a pandas DataFrame
 that includes an 'onset' field.

--- a/nistats/first_level_model.py
+++ b/nistats/first_level_model.py
@@ -1,5 +1,3 @@
-# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
-# vi: set ft=python sts=4 ts=4 sw=4 et:
 """
 This module presents an interface to use the glm implemented in
 nistats.regression.

--- a/nistats/model.py
+++ b/nistats/model.py
@@ -1,5 +1,3 @@
-# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
-# vi: set ft=python sts=4 ts=4 sw=4 et:
 """
 This module implement classes to handle statistical tests on likelihood models
 

--- a/nistats/regression.py
+++ b/nistats/regression.py
@@ -1,5 +1,3 @@
-# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
-# vi: set ft=python sts=4 ts=4 sw=4 et:
 """
 This module implements some standard regression models: OLS and WLS
 models, as well as an AR(p) regression model.

--- a/nistats/tests/test_first_level_model.py
+++ b/nistats/tests/test_first_level_model.py
@@ -1,5 +1,3 @@
-# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
-# vi: set ft=python sts=4 ts=4 sw=4 et:
 """
 Test the first level model.
 """

--- a/nistats/tests/test_second_level_model.py
+++ b/nistats/tests/test_second_level_model.py
@@ -1,5 +1,3 @@
-# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
-# vi: set ft=python sts=4 ts=4 sw=4 et:
 """
 Test the second level model.
 """


### PR DESCRIPTION
some nistats set file local variables for emacs and vim. it is redundant because
it sets them to the defaults of any reasonable configuration, potentially
annoying if these variables have not been marked as safe, and it is not
efficient as it is not done systematically, nor in any nilearn files, nor for
other editors. I therefore suggest we remove these lines before merging into
nilearn.

from nistats dir:
```
   find -name '*.py' -exec sed -i '/^# emacs: -\*-.*/d' {} \;
   find -name '*.py' -exec sed -i '/^# vi: set.*/d' {} \;
```