### PR TITLE
Reduce memory by deleting unmasked run_img

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -16,6 +16,7 @@ Changes
 -------
 
 * Nistats now uses BIDS v1.2 & BIDS Derivatives terminology.
+* `run_img` variable deleted after masking in FirstLevelModel to reduce memory use.
 
 Fixes
 -----

--- a/nistats/first_level_model.py
+++ b/nistats/first_level_model.py
@@ -463,7 +463,7 @@ class FirstLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
                 sys.stderr.write('Starting masker computation \r')
 
             Y = self.masker_.transform(run_img)
-            del run_img
+            del run_img  # Delete unmasked image to save memory
 
             if self.verbose > 1:
                 t_masking = time.time() - t_masking

--- a/nistats/first_level_model.py
+++ b/nistats/first_level_model.py
@@ -8,7 +8,6 @@ of fMRI data analyses.
 Author: Bertrand Thirion, Martin Perez-Guevara, 2016
 
 """
-
 import glob
 import json
 import os
@@ -464,6 +463,7 @@ class FirstLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
                 sys.stderr.write('Starting masker computation \r')
 
             Y = self.masker_.transform(run_img)
+            del run_img
 
             if self.verbose > 1:
                 t_masking = time.time() - t_masking


### PR DESCRIPTION
The `run_img` object is not needed after its masked. Deleting it saves (in my case) around 10x the size of the compressed nifti, which frees up a lot of memory for model fitting.

To give more background, I'm trying to run `nistats` on a cloud server with limited memory. It looks like the bottleneck is not model fitting (peaks at ~2 GB with 2 predictors), but rather loading the unmasked nifti. What is a bit confusing to me is that in this instance I have not passed a mask, so `nilearn` is using a dummy mask of all 1s. Yet, the memory foot print of `Y` is about 6-7x smaller than `run_img`. 

Is there any way to load `run_img` in a way that uses less memory to being with?

In any case, the deletion in this PR helps out a bit. 