### PR TITLE
[FIX] Design matrices are wrong if multiple events in the same regressor have the same onset or offset

### DIFF
--- a/nistats/hemodynamic_models.py
+++ b/nistats/hemodynamic_models.py
@@ -290,7 +290,9 @@ def _sample_condition(exp_condition, frame_times, oversampling=50,
         if t < (tmax - 1) and t == t_onset[i]:
             t_offset[i] += 1
 
-    regressor[t_offset] -= values
+    for t in t_offset:
+        regressor[t_offset] -= values
+
     regressor = np.cumsum(regressor)
 
     return regressor, hr_frame_times

--- a/nistats/hemodynamic_models.py
+++ b/nistats/hemodynamic_models.py
@@ -281,7 +281,9 @@ def _sample_condition(exp_condition, frame_times, oversampling=50,
     tmax = len(hr_frame_times)
     regressor = np.zeros_like(hr_frame_times).astype(np.float)
     t_onset = np.minimum(np.searchsorted(hr_frame_times, onsets), tmax - 1)
-    regressor[t_onset] += values
+    for t, v in zip(t_onset, values):
+        regressor[t] += v
+
     t_offset = np.minimum(np.searchsorted(hr_frame_times, onsets + durations),
                           tmax - 1)
 
@@ -290,8 +292,8 @@ def _sample_condition(exp_condition, frame_times, oversampling=50,
         if t < (tmax - 1) and t == t_onset[i]:
             t_offset[i] += 1
 
-    for t in t_offset:
-        regressor[t_offset] -= values
+    for t, v in zip(t_offset, values):
+        regressor[t] -= v
 
     regressor = np.cumsum(regressor)
 


### PR DESCRIPTION
Dear nistats team,

using  ```first_level_model.make_first_level_design_matrix()``` I noticed that in some cases the baseline of a regressor can shift and never return to zero, instead being stuck at another value (e.g. -1, +1 etc.). I think the issue is that in the function ```hemodynamic_models._sample_condition()``` each onset (e.g. a stick function of +1) has to be balanced by an offset of the same, but negative value (e.g. -1). However, if multiple events start at the same time (+1) but end at different times (-1 + -1 = -2), the baseline will permanently shift downwards. The opposite effect occurs when different onsets have the same offset (then the baseline will be permanently shifted in the positive direction). For some examples, including a possible solution, please see the following notebook:

[https://gist.github.com/mwegrzyn/80a382f30260f5982e8b5dc5c89867fb](https://gist.github.com/mwegrzyn/80a382f30260f5982e8b5dc5c89867fb)

I hope that the suggested pull request is helpful. It's my first one ever, so please let me know if something is not quite ok. Thank you very much!

Best,  
Martin

